### PR TITLE
Testing consistency of sobec::StateLPF with croco::StateMultibody when nu=0

### DIFF
--- a/tests/factory/statelpf.cpp
+++ b/tests/factory/statelpf.cpp
@@ -60,7 +60,7 @@ boost::shared_ptr<sobec::StateLPF> StateLPFModelFactory::create(
   switch (state_type) {
     case StateLPFModelTypes::StateLPF_TalosArm: {
       model = PinocchioModelFactory(PinocchioModelTypes::TalosArm).create();
-      if(!nu0){
+      if (!nu0) {
         boost::shared_ptr<crocoddyl::ActuationModelFull> actuation =
             boost::make_shared<crocoddyl::ActuationModelFull>(
                 StateModelFactory().create(
@@ -73,7 +73,7 @@ boost::shared_ptr<sobec::StateLPF> StateLPFModelFactory::create(
     }
     case StateLPFModelTypes::StateLPF_HyQ: {
       model = PinocchioModelFactory(PinocchioModelTypes::HyQ).create();
-      if(!nu0){
+      if (!nu0) {
         boost::shared_ptr<crocoddyl::ActuationModelFloatingBase> actuation =
             boost::make_shared<crocoddyl::ActuationModelFloatingBase>(
                 boost::static_pointer_cast<crocoddyl::StateMultibody>(
@@ -87,7 +87,7 @@ boost::shared_ptr<sobec::StateLPF> StateLPFModelFactory::create(
     }
     case StateLPFModelTypes::StateLPF_Talos: {
       model = PinocchioModelFactory(PinocchioModelTypes::Talos).create();
-      if(!nu0){
+      if (!nu0) {
         boost::shared_ptr<crocoddyl::ActuationModelFloatingBase> actuation =
             boost::make_shared<crocoddyl::ActuationModelFloatingBase>(
                 boost::static_pointer_cast<crocoddyl::StateMultibody>(
@@ -102,7 +102,7 @@ boost::shared_ptr<sobec::StateLPF> StateLPFModelFactory::create(
     case StateLPFModelTypes::StateLPF_RandomHumanoid: {
       model =
           PinocchioModelFactory(PinocchioModelTypes::RandomHumanoid).create();
-      if(!nu0){
+      if (!nu0) {
         boost::shared_ptr<crocoddyl::ActuationModelFloatingBase> actuation =
             boost::make_shared<crocoddyl::ActuationModelFloatingBase>(
                 boost::static_pointer_cast<crocoddyl::StateMultibody>(

--- a/tests/factory/statelpf.cpp
+++ b/tests/factory/statelpf.cpp
@@ -54,48 +54,64 @@ StateLPFModelFactory::StateLPFModelFactory() {}
 StateLPFModelFactory::~StateLPFModelFactory() {}
 
 boost::shared_ptr<sobec::StateLPF> StateLPFModelFactory::create(
-    StateLPFModelTypes::Type state_type) const {
+    StateLPFModelTypes::Type state_type, bool nu0) const {
   boost::shared_ptr<pinocchio::Model> model;
   boost::shared_ptr<sobec::StateLPF> state;
   switch (state_type) {
     case StateLPFModelTypes::StateLPF_TalosArm: {
       model = PinocchioModelFactory(PinocchioModelTypes::TalosArm).create();
-      boost::shared_ptr<crocoddyl::ActuationModelFull> actuation =
-          boost::make_shared<crocoddyl::ActuationModelFull>(
-              StateModelFactory().create(
-                  StateModelTypes::StateMultibody_TalosArm));
-      state = boost::make_shared<sobec::StateLPF>(model, actuation->get_nu());
+      if(!nu0){
+        boost::shared_ptr<crocoddyl::ActuationModelFull> actuation =
+            boost::make_shared<crocoddyl::ActuationModelFull>(
+                StateModelFactory().create(
+                    StateModelTypes::StateMultibody_TalosArm));
+        state = boost::make_shared<sobec::StateLPF>(model, actuation->get_nu());
+      } else {
+        state = boost::make_shared<sobec::StateLPF>(model, 0);
+      }
       break;
     }
     case StateLPFModelTypes::StateLPF_HyQ: {
       model = PinocchioModelFactory(PinocchioModelTypes::HyQ).create();
-      boost::shared_ptr<crocoddyl::ActuationModelFloatingBase> actuation =
-          boost::make_shared<crocoddyl::ActuationModelFloatingBase>(
-              boost::static_pointer_cast<crocoddyl::StateMultibody>(
-                  StateModelFactory().create(
-                      StateModelTypes::StateMultibody_HyQ)));
-      state = boost::make_shared<sobec::StateLPF>(model, actuation->get_nu());
+      if(!nu0){
+        boost::shared_ptr<crocoddyl::ActuationModelFloatingBase> actuation =
+            boost::make_shared<crocoddyl::ActuationModelFloatingBase>(
+                boost::static_pointer_cast<crocoddyl::StateMultibody>(
+                    StateModelFactory().create(
+                        StateModelTypes::StateMultibody_HyQ)));
+        state = boost::make_shared<sobec::StateLPF>(model, actuation->get_nu());
+      } else {
+        state = boost::make_shared<sobec::StateLPF>(model, 0);
+      }
       break;
     }
     case StateLPFModelTypes::StateLPF_Talos: {
       model = PinocchioModelFactory(PinocchioModelTypes::Talos).create();
-      boost::shared_ptr<crocoddyl::ActuationModelFloatingBase> actuation =
-          boost::make_shared<crocoddyl::ActuationModelFloatingBase>(
-              boost::static_pointer_cast<crocoddyl::StateMultibody>(
-                  StateModelFactory().create(
-                      StateModelTypes::StateMultibody_Talos)));
-      state = boost::make_shared<sobec::StateLPF>(model, actuation->get_nu());
+      if(!nu0){
+        boost::shared_ptr<crocoddyl::ActuationModelFloatingBase> actuation =
+            boost::make_shared<crocoddyl::ActuationModelFloatingBase>(
+                boost::static_pointer_cast<crocoddyl::StateMultibody>(
+                    StateModelFactory().create(
+                        StateModelTypes::StateMultibody_Talos)));
+        state = boost::make_shared<sobec::StateLPF>(model, actuation->get_nu());
+      } else {
+        state = boost::make_shared<sobec::StateLPF>(model, 0);
+      }
       break;
     }
     case StateLPFModelTypes::StateLPF_RandomHumanoid: {
       model =
           PinocchioModelFactory(PinocchioModelTypes::RandomHumanoid).create();
-      boost::shared_ptr<crocoddyl::ActuationModelFloatingBase> actuation =
-          boost::make_shared<crocoddyl::ActuationModelFloatingBase>(
-              boost::static_pointer_cast<crocoddyl::StateMultibody>(
-                  StateModelFactory().create(
-                      StateModelTypes::StateMultibody_RandomHumanoid)));
-      state = boost::make_shared<sobec::StateLPF>(model, actuation->get_nu());
+      if(!nu0){
+        boost::shared_ptr<crocoddyl::ActuationModelFloatingBase> actuation =
+            boost::make_shared<crocoddyl::ActuationModelFloatingBase>(
+                boost::static_pointer_cast<crocoddyl::StateMultibody>(
+                    StateModelFactory().create(
+                        StateModelTypes::StateMultibody_RandomHumanoid)));
+        state = boost::make_shared<sobec::StateLPF>(model, actuation->get_nu());
+      } else {
+        state = boost::make_shared<sobec::StateLPF>(model, 0);
+      }
       break;
     }
     default:

--- a/tests/factory/statelpf.hpp
+++ b/tests/factory/statelpf.hpp
@@ -15,6 +15,7 @@
 
 #include "pinocchio_model.hpp"
 #include "sobec/lowpassfilter/statelpf.hpp"
+#include "state.hpp"
 
 namespace sobec {
 namespace unittest {
@@ -38,6 +39,13 @@ struct StateLPFModelTypes {
   static const std::vector<Type> all;
 };
 
+const std::map<StateLPFModelTypes::Type, StateModelTypes::Type> mapStateLPFToStateMultibody{
+  {StateLPFModelTypes::StateLPF_TalosArm, StateModelTypes::StateMultibody_TalosArm},
+  {StateLPFModelTypes::StateLPF_HyQ, StateModelTypes::StateMultibody_HyQ},
+  {StateLPFModelTypes::StateLPF_Talos, StateModelTypes::StateMultibody_Talos},
+  {StateLPFModelTypes::StateLPF_RandomHumanoid, StateModelTypes::StateMultibody_RandomHumanoid}
+};
+
 std::ostream& operator<<(std::ostream& os, StateLPFModelTypes::Type type);
 
 class StateLPFModelFactory {
@@ -48,7 +56,7 @@ class StateLPFModelFactory {
   ~StateLPFModelFactory();
 
   boost::shared_ptr<sobec::StateLPF> create(
-      StateLPFModelTypes::Type state_type) const;
+      StateLPFModelTypes::Type state_type, bool nu0 = false) const;
 };
 
 }  // namespace unittest

--- a/tests/factory/statelpf.hpp
+++ b/tests/factory/statelpf.hpp
@@ -39,12 +39,15 @@ struct StateLPFModelTypes {
   static const std::vector<Type> all;
 };
 
-const std::map<StateLPFModelTypes::Type, StateModelTypes::Type> mapStateLPFToStateMultibody{
-  {StateLPFModelTypes::StateLPF_TalosArm, StateModelTypes::StateMultibody_TalosArm},
-  {StateLPFModelTypes::StateLPF_HyQ, StateModelTypes::StateMultibody_HyQ},
-  {StateLPFModelTypes::StateLPF_Talos, StateModelTypes::StateMultibody_Talos},
-  {StateLPFModelTypes::StateLPF_RandomHumanoid, StateModelTypes::StateMultibody_RandomHumanoid}
-};
+const std::map<StateLPFModelTypes::Type, StateModelTypes::Type>
+    mapStateLPFToStateMultibody{
+        {StateLPFModelTypes::StateLPF_TalosArm,
+         StateModelTypes::StateMultibody_TalosArm},
+        {StateLPFModelTypes::StateLPF_HyQ, StateModelTypes::StateMultibody_HyQ},
+        {StateLPFModelTypes::StateLPF_Talos,
+         StateModelTypes::StateMultibody_Talos},
+        {StateLPFModelTypes::StateLPF_RandomHumanoid,
+         StateModelTypes::StateMultibody_RandomHumanoid}};
 
 std::ostream& operator<<(std::ostream& os, StateLPFModelTypes::Type type);
 
@@ -55,8 +58,8 @@ class StateLPFModelFactory {
   explicit StateLPFModelFactory();
   ~StateLPFModelFactory();
 
-  boost::shared_ptr<sobec::StateLPF> create(
-      StateLPFModelTypes::Type state_type, bool nu0 = false) const;
+  boost::shared_ptr<sobec::StateLPF> create(StateLPFModelTypes::Type state_type,
+                                            bool nu0 = false) const;
 };
 
 }  // namespace unittest

--- a/tests/test_stateslpf.cpp
+++ b/tests/test_stateslpf.cpp
@@ -39,8 +39,10 @@ void test_state_dimension(StateLPFModelTypes::Type state_type) {
 
   // Check that dimensions matches multibody dimensions when nu=0
   StateModelFactory factoryMultibody;
-  const boost::shared_ptr<sobec::StateLPF>& stateLPF = factory.create(state_type, true);
-  const boost::shared_ptr<crocoddyl::StateAbstract>& stateMultibody = factoryMultibody.create(mapStateLPFToStateMultibody.at(state_type));
+  const boost::shared_ptr<sobec::StateLPF>& stateLPF =
+      factory.create(state_type, true);
+  const boost::shared_ptr<crocoddyl::StateAbstract>& stateMultibody =
+      factoryMultibody.create(mapStateLPFToStateMultibody.at(state_type));
   BOOST_CHECK(stateLPF->get_ny() == stateMultibody->get_nx());
   BOOST_CHECK(stateLPF->get_ndy() == stateMultibody->get_ndx());
   BOOST_CHECK(stateLPF->get_nq() == stateMultibody->get_nq());
@@ -66,11 +68,13 @@ void test_integrate_against_difference(StateLPFModelTypes::Type state_type) {
 
   // Checking that both states agree
   BOOST_CHECK(dxi.isZero(1e-9));
-  
+
   // Check diff against state multibody diff when nu=0
   StateModelFactory factoryMultibody;
-  const boost::shared_ptr<sobec::StateLPF>& stateLPF = factory.create(state_type, true);
-  const boost::shared_ptr<crocoddyl::StateAbstract>& stateMultibody = factoryMultibody.create(mapStateLPFToStateMultibody.at(state_type));
+  const boost::shared_ptr<sobec::StateLPF>& stateLPF =
+      factory.create(state_type, true);
+  const boost::shared_ptr<crocoddyl::StateAbstract>& stateMultibody =
+      factoryMultibody.create(mapStateLPFToStateMultibody.at(state_type));
   // Generating random states
   const Eigen::VectorXd& x3 = stateLPF->rand();
   const Eigen::VectorXd& x4 = stateLPF->rand();
@@ -80,9 +84,8 @@ void test_integrate_against_difference(StateLPFModelTypes::Type state_type) {
   // Difference multibody
   Eigen::VectorXd dxMultibody(stateMultibody->get_ndx());
   stateMultibody->diff(x3, x4, dxMultibody);
-  
-  BOOST_CHECK((dxLPF - dxMultibody).isZero(1e-9));
 
+  BOOST_CHECK((dxLPF - dxMultibody).isZero(1e-9));
 }
 
 void test_difference_against_integrate(StateLPFModelTypes::Type state_type) {
@@ -103,15 +106,17 @@ void test_difference_against_integrate(StateLPFModelTypes::Type state_type) {
 
   // Check integrate against state multibody integrate when nu=0
   StateModelFactory factoryMultibody;
-  const boost::shared_ptr<sobec::StateLPF>& stateLPF = factory.create(state_type, true);
-  const boost::shared_ptr<crocoddyl::StateAbstract>& stateMultibody = factoryMultibody.create(mapStateLPFToStateMultibody.at(state_type));
+  const boost::shared_ptr<sobec::StateLPF>& stateLPF =
+      factory.create(state_type, true);
+  const boost::shared_ptr<crocoddyl::StateAbstract>& stateMultibody =
+      factoryMultibody.create(mapStateLPFToStateMultibody.at(state_type));
   // Generating random states
   const Eigen::VectorXd& x1 = stateLPF->rand();
   const Eigen::VectorXd& dx1 = Eigen::VectorXd::Random(stateLPF->get_ndy());
   // Integrate LPF
   Eigen::VectorXd xLPF(stateLPF->get_ny());
   stateLPF->integrate(x1, dx1, xLPF);
-  // Integrate multibody 
+  // Integrate multibody
   Eigen::VectorXd xMultibody(stateLPF->get_nx());
   stateMultibody->integrate(x1, dx1, xMultibody);
   BOOST_CHECK((xLPF - xMultibody).isZero(1e-9));
@@ -146,8 +151,10 @@ void test_Jdiff_firstsecond(StateLPFModelTypes::Type state_type) {
 
   // Check Jdiff against state multibody when nu=0
   StateModelFactory factoryMultibody;
-  const boost::shared_ptr<sobec::StateLPF>& stateLPF = factory.create(state_type, true);
-  const boost::shared_ptr<crocoddyl::StateAbstract>& stateMultibody = factoryMultibody.create(mapStateLPFToStateMultibody.at(state_type));
+  const boost::shared_ptr<sobec::StateLPF>& stateLPF =
+      factory.create(state_type, true);
+  const boost::shared_ptr<crocoddyl::StateAbstract>& stateMultibody =
+      factoryMultibody.create(mapStateLPFToStateMultibody.at(state_type));
   const Eigen::VectorXd& x3 = stateLPF->rand();
   const Eigen::VectorXd& x4 = stateLPF->rand();
   // Jdiff LPF
@@ -165,19 +172,22 @@ void test_Jdiff_firstsecond(StateLPFModelTypes::Type state_type) {
       Eigen::MatrixXd::Zero(stateLPF->get_ndy(), stateLPF->get_ndy()));
   stateLPF->Jdiff(x3, x4, Jdiff_both_firstLPF, Jdiff_both_secondLPF);
   // Jdiff multibody
-  Eigen::MatrixXd Jdiff_tmpMultibody(
-      Eigen::MatrixXd::Zero(stateMultibody->get_ndx(), stateMultibody->get_ndx()));
-  Eigen::MatrixXd Jdiff_firstMultibody(
-      Eigen::MatrixXd::Zero(stateMultibody->get_ndx(), stateMultibody->get_ndx()));
-  Eigen::MatrixXd Jdiff_secondMultibody(
-      Eigen::MatrixXd::Zero(stateMultibody->get_ndx(), stateMultibody->get_ndx()));
-  stateMultibody->Jdiff(x3, x4, Jdiff_firstMultibody, Jdiff_tmpMultibody, crocoddyl::first);
-  stateMultibody->Jdiff(x3, x4, Jdiff_tmpMultibody, Jdiff_secondMultibody, crocoddyl::second);
-  Eigen::MatrixXd Jdiff_both_firstMultibody(
-      Eigen::MatrixXd::Zero(stateMultibody->get_ndx(), stateMultibody->get_ndx()));
-  Eigen::MatrixXd Jdiff_both_secondMultibody(
-      Eigen::MatrixXd::Zero(stateMultibody->get_ndx(), stateMultibody->get_ndx()));
-  stateMultibody->Jdiff(x3, x4, Jdiff_both_firstMultibody, Jdiff_both_secondMultibody);
+  Eigen::MatrixXd Jdiff_tmpMultibody(Eigen::MatrixXd::Zero(
+      stateMultibody->get_ndx(), stateMultibody->get_ndx()));
+  Eigen::MatrixXd Jdiff_firstMultibody(Eigen::MatrixXd::Zero(
+      stateMultibody->get_ndx(), stateMultibody->get_ndx()));
+  Eigen::MatrixXd Jdiff_secondMultibody(Eigen::MatrixXd::Zero(
+      stateMultibody->get_ndx(), stateMultibody->get_ndx()));
+  stateMultibody->Jdiff(x3, x4, Jdiff_firstMultibody, Jdiff_tmpMultibody,
+                        crocoddyl::first);
+  stateMultibody->Jdiff(x3, x4, Jdiff_tmpMultibody, Jdiff_secondMultibody,
+                        crocoddyl::second);
+  Eigen::MatrixXd Jdiff_both_firstMultibody(Eigen::MatrixXd::Zero(
+      stateMultibody->get_ndx(), stateMultibody->get_ndx()));
+  Eigen::MatrixXd Jdiff_both_secondMultibody(Eigen::MatrixXd::Zero(
+      stateMultibody->get_ndx(), stateMultibody->get_ndx()));
+  stateMultibody->Jdiff(x3, x4, Jdiff_both_firstMultibody,
+                        Jdiff_both_secondMultibody);
 
   BOOST_CHECK((Jdiff_firstLPF - Jdiff_firstMultibody).isZero(1e-9));
   BOOST_CHECK((Jdiff_secondLPF - Jdiff_secondMultibody).isZero(1e-9));
@@ -212,11 +222,12 @@ void test_Jint_firstsecond(StateLPFModelTypes::Type state_type) {
   BOOST_CHECK((Jint_first - Jint_both_first).isZero(1e-9));
   BOOST_CHECK((Jint_second - Jint_both_second).isZero(1e-9));
 
-
   // Check Jintegrate against state multibody Jintegrate when nu=0
   StateModelFactory factoryMultibody;
-  const boost::shared_ptr<sobec::StateLPF>& stateLPF = factory.create(state_type, true);
-  const boost::shared_ptr<crocoddyl::StateAbstract>& stateMultibody = factoryMultibody.create(mapStateLPFToStateMultibody.at(state_type));
+  const boost::shared_ptr<sobec::StateLPF>& stateLPF =
+      factory.create(state_type, true);
+  const boost::shared_ptr<crocoddyl::StateAbstract>& stateMultibody =
+      factoryMultibody.create(mapStateLPFToStateMultibody.at(state_type));
   const Eigen::VectorXd& x1 = stateLPF->rand();
   const Eigen::VectorXd& dx1 = Eigen::VectorXd::Random(stateLPF->get_ndy());
   // Jint LPF
@@ -234,25 +245,27 @@ void test_Jint_firstsecond(StateLPFModelTypes::Type state_type) {
       Eigen::MatrixXd::Zero(stateLPF->get_ndy(), stateLPF->get_ndy()));
   stateLPF->Jintegrate(x1, dx1, Jint_both_firstLPF, Jint_both_secondLPF);
   // Jint multibody
-  Eigen::MatrixXd Jint_tmpMultibody(
-      Eigen::MatrixXd::Zero(stateMultibody->get_ndx(), stateMultibody->get_ndx()));
-  Eigen::MatrixXd Jint_firstMultibody(
-      Eigen::MatrixXd::Zero(stateMultibody->get_ndx(), stateMultibody->get_ndx()));
-  Eigen::MatrixXd Jint_secondMultibody(
-      Eigen::MatrixXd::Zero(stateMultibody->get_ndx(), stateMultibody->get_ndx()));
-  stateMultibody->Jintegrate(x1, dx1, Jint_firstMultibody, Jint_tmpMultibody, crocoddyl::first);
-  stateMultibody->Jintegrate(x1, dx1, Jint_tmpMultibody, Jint_secondMultibody, crocoddyl::second);
-  Eigen::MatrixXd Jint_both_firstMultibody(
-      Eigen::MatrixXd::Zero(stateMultibody->get_ndx(), stateMultibody->get_ndx()));
-  Eigen::MatrixXd Jint_both_secondMultibody(
-      Eigen::MatrixXd::Zero(stateMultibody->get_ndx(), stateMultibody->get_ndx()));
-  stateMultibody->Jintegrate(x1, dx1, Jint_both_firstMultibody, Jint_both_secondMultibody);
+  Eigen::MatrixXd Jint_tmpMultibody(Eigen::MatrixXd::Zero(
+      stateMultibody->get_ndx(), stateMultibody->get_ndx()));
+  Eigen::MatrixXd Jint_firstMultibody(Eigen::MatrixXd::Zero(
+      stateMultibody->get_ndx(), stateMultibody->get_ndx()));
+  Eigen::MatrixXd Jint_secondMultibody(Eigen::MatrixXd::Zero(
+      stateMultibody->get_ndx(), stateMultibody->get_ndx()));
+  stateMultibody->Jintegrate(x1, dx1, Jint_firstMultibody, Jint_tmpMultibody,
+                             crocoddyl::first);
+  stateMultibody->Jintegrate(x1, dx1, Jint_tmpMultibody, Jint_secondMultibody,
+                             crocoddyl::second);
+  Eigen::MatrixXd Jint_both_firstMultibody(Eigen::MatrixXd::Zero(
+      stateMultibody->get_ndx(), stateMultibody->get_ndx()));
+  Eigen::MatrixXd Jint_both_secondMultibody(Eigen::MatrixXd::Zero(
+      stateMultibody->get_ndx(), stateMultibody->get_ndx()));
+  stateMultibody->Jintegrate(x1, dx1, Jint_both_firstMultibody,
+                             Jint_both_secondMultibody);
 
   BOOST_CHECK((Jint_firstLPF - Jint_firstMultibody).isZero(1e-9));
   BOOST_CHECK((Jint_secondLPF - Jint_secondMultibody).isZero(1e-9));
   BOOST_CHECK((Jint_both_firstLPF - Jint_both_firstMultibody).isZero(1e-9));
   BOOST_CHECK((Jint_both_secondLPF - Jint_both_secondMultibody).isZero(1e-9));
-
 }
 
 void test_Jdiff_num_diff_firstsecond(StateLPFModelTypes::Type state_type) {
@@ -384,20 +397,21 @@ void test_Jintegrate_against_numdiff(StateLPFModelTypes::Type state_type) {
   BOOST_CHECK((Jint_1 - Jint_num_1).isZero(tol));
   BOOST_CHECK((Jint_2 - Jint_num_2).isZero(tol));
 
-
   // Check Jdiff against state multibody when nu=0
   StateModelFactory factoryMultibody;
-  const boost::shared_ptr<sobec::StateLPF>& stateLPF = factory.create(state_type, true);
-  const boost::shared_ptr<crocoddyl::StateAbstract>& stateMultibody = factoryMultibody.create(mapStateLPFToStateMultibody.at(state_type));
+  const boost::shared_ptr<sobec::StateLPF>& stateLPF =
+      factory.create(state_type, true);
+  const boost::shared_ptr<crocoddyl::StateAbstract>& stateMultibody =
+      factoryMultibody.create(mapStateLPFToStateMultibody.at(state_type));
   Eigen::MatrixXd Jint_1LPF(
       Eigen::MatrixXd::Zero(stateLPF->get_ndy(), stateLPF->get_ndy()));
   Eigen::MatrixXd Jint_2LPF(
       Eigen::MatrixXd::Zero(stateLPF->get_ndy(), stateLPF->get_ndy()));
   stateLPF->Jintegrate(x, dx, Jint_1LPF, Jint_2LPF);
-  Eigen::MatrixXd Jint_1Multibody(
-      Eigen::MatrixXd::Zero(stateMultibody->get_ndx(), stateMultibody->get_ndx()));
-  Eigen::MatrixXd Jint_2Multibody(
-      Eigen::MatrixXd::Zero(stateMultibody->get_ndx(), stateMultibody->get_ndx()));
+  Eigen::MatrixXd Jint_1Multibody(Eigen::MatrixXd::Zero(
+      stateMultibody->get_ndx(), stateMultibody->get_ndx()));
+  Eigen::MatrixXd Jint_2Multibody(Eigen::MatrixXd::Zero(
+      stateMultibody->get_ndx(), stateMultibody->get_ndx()));
   stateMultibody->Jintegrate(x, dx, Jint_1Multibody, Jint_2Multibody);
 
   BOOST_CHECK((Jint_1LPF - Jint_1Multibody).isZero(tol));
@@ -429,18 +443,20 @@ void test_JintegrateTransport(StateLPFModelTypes::Type state_type) {
   state->JintegrateTransport(x, dx, Jref, crocoddyl::second);
   BOOST_CHECK((Jref - Jint_2 * Jtest).isZero(1e-10));
 
-
-  // Check JintegrateTransport against state multibody JintegrateTransport when nu=0
+  // Check JintegrateTransport against state multibody JintegrateTransport when
+  // nu=0
   StateModelFactory factoryMultibody;
-  const boost::shared_ptr<sobec::StateLPF>& stateLPF = factory.create(state_type, true);
-  const boost::shared_ptr<crocoddyl::StateAbstract>& stateMultibody = factoryMultibody.create(mapStateLPFToStateMultibody.at(state_type)); 
+  const boost::shared_ptr<sobec::StateLPF>& stateLPF =
+      factory.create(state_type, true);
+  const boost::shared_ptr<crocoddyl::StateAbstract>& stateMultibody =
+      factoryMultibody.create(mapStateLPFToStateMultibody.at(state_type));
   const Eigen::VectorXd& x1 = stateLPF->rand();
   const Eigen::VectorXd& dx1 = Eigen::VectorXd::Random(stateLPF->get_ndy());
   Eigen::MatrixXd JrefLPF(
       Eigen::MatrixXd::Random(state->get_ndy(), 2 * state->get_ndy()));
   Eigen::MatrixXd JrefMultibody(JrefLPF);
   const Eigen::MatrixXd Jtest1(JrefLPF);
-  // test first 
+  // test first
   stateLPF->JintegrateTransport(x1, dx1, JrefLPF, crocoddyl::first);
   stateMultibody->JintegrateTransport(x1, dx1, JrefMultibody, crocoddyl::first);
   BOOST_CHECK((JrefLPF - JrefMultibody).isZero(1e-10));
@@ -449,7 +465,8 @@ void test_JintegrateTransport(StateLPFModelTypes::Type state_type) {
   JrefMultibody = Jtest1;
   // test second
   stateLPF->JintegrateTransport(x1, dx1, JrefLPF, crocoddyl::second);
-  stateMultibody->JintegrateTransport(x1, dx1, JrefMultibody, crocoddyl::second);
+  stateMultibody->JintegrateTransport(x1, dx1, JrefMultibody,
+                                      crocoddyl::second);
   BOOST_CHECK((JrefLPF - JrefMultibody).isZero(1e-10));
 }
 
@@ -520,8 +537,6 @@ void test_velocity_from_Jintegrate_Jdiff(StateLPFModelTypes::Type state_type) {
   BOOST_CHECK((J2 * eps - (-dx + dxi) / h).isZero(1e-3));
 }
 
-
-
 //----------------------------------------------------------------------------//
 
 void register_state_unit_tests(StateLPFModelTypes::Type state_type) {
@@ -557,7 +572,6 @@ bool init_function() {
   for (size_t i = 0; i < StateLPFModelTypes::all.size(); ++i) {
     register_state_unit_tests(StateLPFModelTypes::all[i]);
   }
-
 
   return true;
 }


### PR DESCRIPTION
Added unittests to check that sobec::StateLPF is equivalent to crocoddyl::StateMultibody when nu=0 