### PR TITLE
Added unittests for IntegratedActionModelLPF + fix some warnings

### DIFF
--- a/include/sobec/crocomplements/contact/contact1d.hpp
+++ b/include/sobec/crocomplements/contact/contact1d.hpp
@@ -137,7 +137,7 @@ class ContactModel1DTpl : public crocoddyl::ContactModel1DTpl<_Scalar> {
   /**
    * @brief Get pinocchio::ReferenceFrame
    */
-  const pinocchio::ReferenceFrame get_type() const;
+  const pinocchio::ReferenceFrame& get_type() const;
 
   /**
    * @brief Modify contact 1D mask
@@ -147,7 +147,7 @@ class ContactModel1DTpl : public crocoddyl::ContactModel1DTpl<_Scalar> {
   /**
    * @brief Get contact 1D mask
    */
-  const Vector3MaskType get_mask() const;
+  const Vector3MaskType& get_mask() const;
 
   /**
    * @brief Print relevant information of the 1d contact model

--- a/include/sobec/crocomplements/contact/contact1d.hxx
+++ b/include/sobec/crocomplements/contact/contact1d.hxx
@@ -205,7 +205,7 @@ void ContactModel1DTpl<Scalar>::set_type(const pinocchio::ReferenceFrame type) {
 }
 
 template <typename Scalar>
-const pinocchio::ReferenceFrame ContactModel1DTpl<Scalar>::get_type() const {
+const pinocchio::ReferenceFrame& ContactModel1DTpl<Scalar>::get_type() const {
   return type_;
 }
 
@@ -215,7 +215,7 @@ void ContactModel1DTpl<Scalar>::set_mask(const Vector3MaskType mask) {
 }
 
 template <typename Scalar>
-const Vector3MaskType ContactModel1DTpl<Scalar>::get_mask() const {
+const Vector3MaskType& ContactModel1DTpl<Scalar>::get_mask() const {
   return mask_;
 }
 

--- a/include/sobec/crocomplements/contact/contact3d.hpp
+++ b/include/sobec/crocomplements/contact/contact3d.hpp
@@ -130,7 +130,7 @@ class ContactModel3DTpl : public crocoddyl::ContactModel3DTpl<_Scalar> {
   /**
    * @brief Get pinocchio::ReferenceFrame
    */
-  const pinocchio::ReferenceFrame get_type() const;
+  const pinocchio::ReferenceFrame& get_type() const;
 
   /**
    * @brief Print relevant information of the 3d contact model

--- a/include/sobec/crocomplements/contact/contact3d.hxx
+++ b/include/sobec/crocomplements/contact/contact3d.hxx
@@ -199,7 +199,7 @@ void ContactModel3DTpl<Scalar>::set_type(const pinocchio::ReferenceFrame type) {
 }
 
 template <typename Scalar>
-const pinocchio::ReferenceFrame ContactModel3DTpl<Scalar>::get_type() const {
+const pinocchio::ReferenceFrame& ContactModel3DTpl<Scalar>::get_type() const {
   return type_;
 }
 

--- a/include/sobec/crocomplements/lowpassfilter/action.hpp
+++ b/include/sobec/crocomplements/lowpassfilter/action.hpp
@@ -79,6 +79,10 @@ class IntegratedActionModelLPFTpl : public ActionModelAbstractTpl<_Scalar> {
     return lpf_joint_names_;
   };
 
+  const std::vector<int>& get_lpf_torque_ids() const {
+    return lpf_torque_ids_;
+  };
+
   void set_dt(const Scalar& dt);
   void set_fc(const Scalar& fc);
   void set_alpha(const Scalar& alpha);
@@ -113,9 +117,9 @@ class IntegratedActionModelLPFTpl : public ActionModelAbstractTpl<_Scalar> {
   boost::shared_ptr<DifferentialActionModelAbstract> differential_;
   Scalar time_step_;
   Scalar time_step2_;
-  Scalar fc_;
   Scalar alpha_;
   bool with_cost_residual_;
+  Scalar fc_;
   bool enable_integration_;
   Scalar tauReg_weight_;  //!< Cost weight for unfiltered torque regularization
   VectorXs tauReg_reference_;  //!< Cost reference for unfiltered torque

--- a/include/sobec/crocomplements/lowpassfilter/action.hpp
+++ b/include/sobec/crocomplements/lowpassfilter/action.hpp
@@ -81,6 +81,7 @@ class IntegratedActionModelLPFTpl : public ActionModelAbstractTpl<_Scalar> {
 
   void set_dt(const Scalar& dt);
   void set_fc(const Scalar& fc);
+  void set_alpha(const Scalar& alpha);
   void set_differential(
       boost::shared_ptr<DifferentialActionModelAbstract> model);
 

--- a/include/sobec/crocomplements/lowpassfilter/action.hxx
+++ b/include/sobec/crocomplements/lowpassfilter/action.hxx
@@ -28,9 +28,8 @@ IntegratedActionModelLPFTpl<Scalar>::IntegratedActionModelLPFTpl(
       time_step2_(time_step * time_step),
       with_cost_residual_(with_cost_residual),
       fc_(fc),
-      tau_plus_integration_(tau_plus_integration),
       nw_(model->get_nu()),
-      ntau_(lpf_joint_names.size()),
+      tau_plus_integration_(tau_plus_integration),
       ny_(model->get_state()->get_nx() + lpf_joint_names.size()),
       enable_integration_(true),
       filter_(filter),
@@ -41,6 +40,7 @@ IntegratedActionModelLPFTpl<Scalar>::IntegratedActionModelLPFTpl(
   pin_model_ = state->get_pinocchio();
   // Check that used-specified LPF joints are valid (no free-flyer) and collect
   // ids
+  ntau_ = lpf_joint_names.size();
   for (std::vector<std::string>::iterator iter = lpf_joint_names.begin();
        iter != lpf_joint_names.end(); ++iter) {
     std::size_t jointId = pin_model_->getJointId(*iter);

--- a/include/sobec/crocomplements/lowpassfilter/action.hxx
+++ b/include/sobec/crocomplements/lowpassfilter/action.hxx
@@ -44,7 +44,7 @@ IntegratedActionModelLPFTpl<Scalar>::IntegratedActionModelLPFTpl(
   for (std::vector<std::string>::iterator iter = lpf_joint_names.begin();
        iter != lpf_joint_names.end(); ++iter) {
     std::size_t jointId = pin_model_->getJointId(*iter);
-    lpf_joint_ids_.push_back(jointId);
+    lpf_joint_ids_.push_back(static_cast<int>(jointId));
     std::size_t jointNv = pin_model_->nvs[jointId];
     if (jointNv != (std::size_t)1) {
       throw_pretty(
@@ -115,7 +115,6 @@ void IntegratedActionModelLPFTpl<Scalar>::calc(
     const boost::shared_ptr<ActionDataAbstract>& data,
     const Eigen::Ref<const VectorXs>& y, const Eigen::Ref<const VectorXs>& w) {
   const std::size_t& nv = differential_->get_state()->get_nv();
-  const std::size_t& nq = differential_->get_state()->get_nq();
   const std::size_t& nx = differential_->get_state()->get_nx();
 
   if (static_cast<std::size_t>(y.size()) != ny_) {
@@ -138,7 +137,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calc(
 #if EIGEN_VERSION_AT_LEAST(3, 4, 0)
   d->tau_tmp(lpf_torque_ids_) = y.tail(ntau_);  // LPF dimensions
 #else
-  for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+  for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
     d->tau_tmp(lpf_torque_ids_[i]) = y.tail(ntau_)(i);
   }
 #endif
@@ -227,7 +226,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calc(
 #if EIGEN_VERSION_AT_LEAST(3, 4, 0)
     d->dy.tail(ntau_) = ((1 - alpha_) * (w - tau))(lpf_torque_ids_);
 #else
-    for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+    for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
       d->dy.tail(ntau_)(i) = ((1 - alpha_) * (w - tau))(lpf_torque_ids_[i]);
     }
 #endif
@@ -240,7 +239,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calc(
 #if EIGEN_VERSION_AT_LEAST(3, 4, 0)
       tauReg_residual_ = w(lpf_torque_ids_) - tauReg_reference_;
 #else
-      for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+      for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
         tauReg_residual_(i) = w(lpf_torque_ids_[i]) - tauReg_reference_(i);
       }
 #endif
@@ -255,7 +254,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calc(
           w(lpf_torque_ids_));  // Compute limit cost torque residual of w
       tauLim_residual_ = w(lpf_torque_ids_);
 #else
-      for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+      for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
         tauLim_residual_(i) = w(lpf_torque_ids_[i]);
       }
       activation_model_tauLim_->calc(
@@ -296,7 +295,6 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
     const boost::shared_ptr<ActionDataAbstract>& data,
     const Eigen::Ref<const VectorXs>& y, const Eigen::Ref<const VectorXs>& w) {
   const std::size_t& nv = differential_->get_state()->get_nv();
-  const std::size_t& nq = differential_->get_state()->get_nq();
   const std::size_t& nx = differential_->get_state()->get_nx();
   const std::size_t& ndx = differential_->get_state()->get_ndx();
 
@@ -322,7 +320,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
 #if EIGEN_VERSION_AT_LEAST(3, 4, 0)
   d->tau_tmp(lpf_torque_ids_) = y.tail(ntau_);  // LPF dimensions
 #else
-  for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+  for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
     d->tau_tmp(lpf_torque_ids_[i]) = y.tail(ntau_)(i);
   }
 #endif
@@ -338,7 +336,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
 #if EIGEN_VERSION_AT_LEAST(3, 4, 0)
         activation_model_tauLim_->calcDiff(d->activation, w(lpf_torque_ids_));
 #else
-        for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+        for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
           tauLim_residual_(i) = w(lpf_torque_ids_[i]);
         }
         activation_model_tauLim_->calcDiff(d->activation, tauLim_residual_);
@@ -361,7 +359,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
       d->Fy.block(nv, ndx, nv, ntau_).noalias() =
           da_du(Eigen::all, lpf_torque_ids_) * time_step_;
 #else
-      for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+      for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
         d->Fy.block(0, ndx, nv, ntau_).col(i).noalias() =
             da_du.col(lpf_torque_ids_[i]) * time_step2_;
         d->Fy.block(nv, ndx, nv, ntau_).col(i).noalias() =
@@ -395,7 +393,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
       d->Lyy.bottomRightCorner(ntau_, ntau_).noalias() =
           time_step_ * d->differential->Luu(lpf_torque_ids_, lpf_torque_ids_);
 #else
-      for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+      for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
         d->Ly.tail(ntau_)(i) =
             time_step_ * d->differential->Lu(lpf_torque_ids_[i]);
         d->Lyy.topLeftCorner(ndx, ndx).noalias() =
@@ -405,7 +403,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
         d->Lyy.block(ndx, 0, ntau_, ndx).row(i).noalias() =
             time_step_ *
             d->differential->Lxu.transpose().row(lpf_torque_ids_[i]);
-        for (int j = 0; j < lpf_torque_ids_.size(); j++) {
+        for (std::size_t j = 0; j < lpf_torque_ids_.size(); j++) {
           d->Lyy.bottomRightCorner(ntau_, ntau_)(i, j) =
               time_step_ *
               d->differential->Luu(lpf_torque_ids_[i], lpf_torque_ids_[j]);
@@ -422,7 +420,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
         d->Lww.diagonal().array()(lpf_torque_ids_) =
             Scalar(time_step_ * tauReg_weight_);  // tau reg
 #else
-        for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+        for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
           d->Lw(lpf_torque_ids_[i]) =
               time_step_ * tauReg_weight_ *
               d->r(differential_->get_nr() + i);  // tau reg
@@ -439,7 +437,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
             time_step_ * tauLim_weight_ *
             d->activation->Arr.diagonal();  // tau lim
 #else
-        for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+        for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
           d->Lw(lpf_torque_ids_[i]) +=
               time_step_ * tauLim_weight_ * d->activation->Ar(i);  // tau lim
           d->Lww.diagonal()(lpf_torque_ids_[i]) +=
@@ -465,14 +463,14 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
       d->Lyy.bottomRightCorner(ntau_, ntau_).noalias() =
           d->differential->Luu(lpf_torque_ids_, lpf_torque_ids_);
 #else
-      for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+      for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
         d->Ly.tail(ntau_)(i) = d->differential->Lu(lpf_torque_ids_[i]);
         d->Lyy.topLeftCorner(ndx, ndx).noalias() = d->differential->Lxx;
         d->Lyy.block(0, ndx, ndx, ntau_).col(i).noalias() =
             d->differential->Lxu.col(lpf_torque_ids_[i]);
         d->Lyy.block(ndx, 0, ntau_, ndx).row(i).noalias() =
             d->differential->Lxu.transpose().row(lpf_torque_ids_[i]);
-        for (int j = 0; j < lpf_torque_ids_.size(); j++) {
+        for (std::size_t j = 0; j < lpf_torque_ids_.size(); j++) {
           d->Lyy.bottomRightCorner(ntau_, ntau_)(i, j) =
               d->differential->Luu(lpf_torque_ids_[i], lpf_torque_ids_[j]);
         }
@@ -508,14 +506,14 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
       d->Fy.block(nv, ndx, nv, ntau_).noalias() =
           alpha_ * da_du(Eigen::all, lpf_torque_ids_) * time_step_;
 #else
-      for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+      for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
         d->Fy.block(0, ndx, nv, ntau_).col(i).noalias() =
             alpha_ * alpha_ * da_du.col(lpf_torque_ids_[i]) * time_step2_;
         d->Fy.block(nv, ndx, nv, ntau_).col(i).noalias() =
             alpha_ * da_du.col(lpf_torque_ids_[i]) * time_step_;
       }
 #endif
-      d->Fy.block(0, nq, nv, nv).diagonal().array() +=
+      d->Fy.block(0, nv, nv, nv).diagonal().array() +=
           Scalar(time_step_);  // dt*identity top row middle col (eq.
                                // Jsecond = d(xnext)/d(dx))
       // d->Fy.topLeftCorner(nx, nx).diagonal().array() += Scalar(1.);     //
@@ -526,7 +524,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
       d->Fw.block(nv, 0, nv, ntau_).noalias() =
           da_du(Eigen::all, lpf_torque_ids_) * time_step_ * (1 - alpha_);
 #else
-      for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+      for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
         d->Fw.block(nv, 0, nv, ntau_).col(i).noalias() =
             da_du.col(lpf_torque_ids_[i]) * time_step_ * (1 - alpha_);
       }
@@ -544,7 +542,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
           alpha_ * time_step_ * d->differential->Lu(lpf_torque_ids_);
 
 #else
-      for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+      for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
         d->Ly.tail(ntau_)(i) =
             alpha_ * time_step_ * d->differential->Lu(lpf_torque_ids_[i]);
       }
@@ -569,7 +567,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
           (1 - alpha_) * alpha_ * time_step_ *
           d->differential->Luu(lpf_torque_ids_, lpf_torque_ids_);
 #else
-      for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+      for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
         d->Lyy.block(0, ndx, ndx, ntau_).col(i).noalias() =
             alpha_ * time_step_ * d->differential->Lxu.col(lpf_torque_ids_[i]);
         d->Lyy.block(ndx, 0, ntau_, ndx).row(i).noalias() =
@@ -578,7 +576,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
         d->Lyw.topRows(ndx).col(i).noalias() =
             (1 - alpha_) * time_step_ *
             d->differential->Lxu.col(lpf_torque_ids_[i]);
-        for (int j = 0; j < lpf_torque_ids_.size(); j++) {
+        for (std::size_t j = 0; j < lpf_torque_ids_.size(); j++) {
           d->Lyy.bottomRightCorner(ntau_, ntau_)(i, j) =
               alpha_ * alpha_ * time_step_ *
               d->differential->Luu(lpf_torque_ids_[i], lpf_torque_ids_[j]);
@@ -627,7 +625,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
           (1 - alpha_) * alpha_ *
           d->differential->Luu(lpf_torque_ids_, lpf_torque_ids_);
 #else
-      for (int i = 0; i < lpf_torque_ids_.size(); i++) {
+      for (std::size_t i = 0; i < lpf_torque_ids_.size(); i++) {
         d->Ly.tail(ntau_)(i) = alpha_ * d->differential->Lu(lpf_torque_ids_[i]);
         d->Lw.noalias() = (1 - alpha_) * d->differential->Lu;
         d->Lyy.topLeftCorner(ndx, ndx).noalias() = d->differential->Lxx;
@@ -636,7 +634,7 @@ void IntegratedActionModelLPFTpl<Scalar>::calcDiff(
         d->Lyy.block(ndx, 0, ntau_, ndx).row(i).noalias() =
             alpha_ * d->differential->Lxu.transpose().row(lpf_torque_ids_[i]);
         d->Lyw.topRows(ndx).noalias() = (1 - alpha_) * d->differential->Lxu;
-        for (int j = 0; j < lpf_torque_ids_.size(); j++) {
+        for (std::size_t j = 0; j < lpf_torque_ids_.size(); j++) {
           d->Lyy.bottomRightCorner(ntau_, ntau_)(i, j) =
               alpha_ * alpha_ *
               d->differential->Luu(lpf_torque_ids_[i], lpf_torque_ids_[j]);
@@ -716,6 +714,17 @@ void IntegratedActionModelLPFTpl<Scalar>::set_fc(const Scalar& fc) {
 }
 
 template <typename Scalar>
+void IntegratedActionModelLPFTpl<Scalar>::set_alpha(const Scalar& alpha) {
+  // Set the cut-off frequency
+  if (alpha < 0. || alpha > 1) {
+    throw_pretty("Invalid argument: "
+                 << "alpha must be in [0,1]");
+  } else {
+    alpha_ = alpha;
+  }
+}
+
+template <typename Scalar>
 void IntegratedActionModelLPFTpl<Scalar>::compute_alpha(const Scalar& fc) {
   // Update alpha parameter
   if (fc > 0 && time_step_ != 0) {
@@ -758,10 +767,10 @@ void IntegratedActionModelLPFTpl<Scalar>::set_differential(
 template <typename Scalar>
 void IntegratedActionModelLPFTpl<Scalar>::set_control_reg_cost(
     const Scalar& weight, const VectorXs& ref) {
-  if (weight <= 0.) {
+  if (weight < 0.) {
     throw_pretty("cost weight is positive ");
   }
-  if (ref.size() != ntau_) {
+  if ((std::size_t)ref.size() != (std::size_t)(ntau_)) {
     throw_pretty("cost ref must have size " << ntau_);
   }
   tauReg_weight_ = weight;
@@ -771,7 +780,7 @@ void IntegratedActionModelLPFTpl<Scalar>::set_control_reg_cost(
 template <typename Scalar>
 void IntegratedActionModelLPFTpl<Scalar>::set_control_lim_cost(
     const Scalar& weight) {
-  if (weight <= 0.) {
+  if (weight < 0.) {
     throw_pretty("cost weight is positive ");
   }
   tauLim_weight_ = weight;

--- a/include/sobec/crocomplements/lowpassfilter/state.hxx
+++ b/include/sobec/crocomplements/lowpassfilter/state.hxx
@@ -48,7 +48,7 @@ StateLPFTpl<Scalar>::StateLPFTpl(
   // -pinocchio_->effortLimit.tail[model->idx_vs[lpf_joint_ids[i]]];
   // ub_.tail(ntau_) =
   // pinocchio_->effortLimit.tail(nw_)[model->idx_vs[lpf_joint_ids[i]]];
-  for (int i = 0; i < lpf_joint_ids.size(); i++) {
+  for (std::size_t i = 0; i < lpf_joint_ids.size(); i++) {
     if ((int)model->nvs[lpf_joint_ids[i]] != (int)1) {
       throw_pretty("Invalid argument: "
                    << "Joint " << lpf_joint_ids[i]

--- a/tests/factory/lpf.cpp
+++ b/tests/factory/lpf.cpp
@@ -150,9 +150,9 @@ ActionModelLPFFactory::create(ActionModelLPFTypes::Type iam_type,
           dam, lpf_joint_names, time_step, with_cost_residual, fc,
           tau_plus_integration, filter, is_terminal);
       // set hard-coded costs on unfiltered torque
-      double tauReg_weight = 0.001;
+      double tauReg_weight = 0.;
       Eigen::VectorXd tauReg_ref = Eigen::VectorXd::Zero(iam->get_ntau());
-      double tauLim_weight = 0.1;
+      double tauLim_weight = 0.;
       iam->set_control_reg_cost(tauReg_weight, tauReg_ref);
       iam->set_control_lim_cost(tauLim_weight);
       iam->set_alpha(alpha);

--- a/tests/factory/lpf.cpp
+++ b/tests/factory/lpf.cpp
@@ -27,6 +27,9 @@ std::ostream& operator<<(std::ostream& os, ActionModelLPFTypes::Type type) {
     case ActionModelLPFTypes::IntegratedActionModelLPF_NONE:
       os << "IntegratedActionModelLPF_NONE";
       break;
+    case ActionModelLPFTypes::IntegratedActionModelLPF_alpha0:
+      os << "IntegratedActionModelLPF_alpha0";
+      break;
     case ActionModelLPFTypes::NbActionModelLPFTypes:
       os << "NbActionModelLPFTypes";
       break;
@@ -125,6 +128,34 @@ ActionModelLPFFactory::create(ActionModelLPFTypes::Type iam_type,
       double tauLim_weight = 1.;
       iam->set_control_reg_cost(tauReg_weight, tauReg_ref);
       iam->set_control_lim_cost(tauLim_weight);
+      break;
+    }
+    case ActionModelLPFTypes::IntegratedActionModelLPF_alpha0: {
+      double time_step = 1e-6;
+      bool with_cost_residual = true;
+      double alpha = 0.;
+      double fc = 50000;
+      bool tau_plus_integration = false;
+      int filter = 1;
+      bool is_terminal = false;
+      // Select LPF joints
+      boost::shared_ptr<crocoddyl::StateMultibody> stateMultibody =
+          boost::static_pointer_cast<crocoddyl::StateMultibody>(
+              dam->get_state());
+      boost::shared_ptr<pinocchio::Model> model =
+          stateMultibody->get_pinocchio();
+      std::vector<std::string> lpf_joint_names =
+          LPFJointListFactory().create_names(model, LPFJointMaskType::ALL);
+      iam = boost::make_shared<sobec::IntegratedActionModelLPF>(
+          dam, lpf_joint_names, time_step, with_cost_residual, fc,
+          tau_plus_integration, filter, is_terminal);
+      // set hard-coded costs on unfiltered torque
+      double tauReg_weight = 0.001;
+      Eigen::VectorXd tauReg_ref = Eigen::VectorXd::Zero(iam->get_ntau());
+      double tauLim_weight = 0.1;
+      iam->set_control_reg_cost(tauReg_weight, tauReg_ref);
+      iam->set_control_lim_cost(tauLim_weight);
+      iam->set_alpha(alpha);
       break;
     }
     default:

--- a/tests/factory/lpf.hpp
+++ b/tests/factory/lpf.hpp
@@ -24,7 +24,7 @@ struct ActionModelLPFTypes {
     IntegratedActionModelLPF_ALL,
     IntegratedActionModelLPF_RAND,
     IntegratedActionModelLPF_NONE,
-    // IntegratedActionModelLPF_zero_costs,
+    IntegratedActionModelLPF_alpha0,
     // IntegratedActionModelLPF_terminal,
     NbActionModelLPFTypes
   };

--- a/tests/factory/statelpf.cpp
+++ b/tests/factory/statelpf.cpp
@@ -64,7 +64,7 @@ std::vector<int> LPFJointListFactory::create_ids(
            iter != model->names.end(); ++iter) {
         if (static_cast<int>(model->getJointId(*iter)) < model->njoints &&
             model->nvs[model->getJointId(*iter)] == 1) {
-          lpf_joint_ids.push_back((int)model->getJointId(*iter));
+          lpf_joint_ids.push_back(static_cast<int>(model->getJointId(*iter)));
         }
       }
       break;

--- a/tests/factory/statelpf.cpp
+++ b/tests/factory/statelpf.cpp
@@ -34,7 +34,7 @@ std::vector<std::string> LPFJointListFactory::create_names(
     case LPFJointMaskType::ALL: {
       for (std::vector<std::string>::iterator iter = model->names.begin();
            iter != model->names.end(); ++iter) {
-        if (model->getJointId(*iter) < model->njoints &&
+        if ((int)model->getJointId(*iter) < model->njoints &&
             model->nvs[model->getJointId(*iter)] == 1) {
           lpf_joint_names.push_back(*iter);
         }
@@ -62,9 +62,9 @@ std::vector<int> LPFJointListFactory::create_ids(
     case LPFJointMaskType::ALL: {
       for (std::vector<std::string>::iterator iter = model->names.begin();
            iter != model->names.end(); ++iter) {
-        if (model->getJointId(*iter) < model->njoints &&
+        if ((int)model->getJointId(*iter) < model->njoints &&
             model->nvs[model->getJointId(*iter)] == 1) {
-          lpf_joint_ids.push_back(model->getJointId(*iter));
+          lpf_joint_ids.push_back((int)model->getJointId(*iter));
         }
       }
       break;

--- a/tests/factory/statelpf.cpp
+++ b/tests/factory/statelpf.cpp
@@ -34,7 +34,7 @@ std::vector<std::string> LPFJointListFactory::create_names(
     case LPFJointMaskType::ALL: {
       for (std::vector<std::string>::iterator iter = model->names.begin();
            iter != model->names.end(); ++iter) {
-        if ((int)model->getJointId(*iter) < model->njoints &&
+        if (static_cast<int>(model->getJointId(*iter)) < model->njoints &&
             model->nvs[model->getJointId(*iter)] == 1) {
           lpf_joint_names.push_back(*iter);
         }

--- a/tests/factory/statelpf.cpp
+++ b/tests/factory/statelpf.cpp
@@ -62,7 +62,7 @@ std::vector<int> LPFJointListFactory::create_ids(
     case LPFJointMaskType::ALL: {
       for (std::vector<std::string>::iterator iter = model->names.begin();
            iter != model->names.end(); ++iter) {
-        if ((int)model->getJointId(*iter) < model->njoints &&
+        if (static_cast<int>(model->getJointId(*iter)) < model->njoints &&
             model->nvs[model->getJointId(*iter)] == 1) {
           lpf_joint_ids.push_back((int)model->getJointId(*iter));
         }

--- a/tests/test_lpf.cpp
+++ b/tests/test_lpf.cpp
@@ -11,11 +11,11 @@
 #define BOOST_TEST_NO_MAIN
 #define BOOST_TEST_ALTERNATIVE_INIT_API
 
+#include <crocoddyl/core/integrator/euler.hpp>
+
 #include "common.hpp"
 #include "factory/diff-action.hpp"
 #include "factory/lpf.hpp"
-
-#include <crocoddyl/core/integrator/euler.hpp>
 
 using namespace boost::unit_test;
 using namespace sobec::unittest;
@@ -157,41 +157,43 @@ void test_partial_derivatives_action_model(
   test_partial_derivatives_against_numdiff(model);
 }
 
-
-
-void test_calc_alpha0_equivalent_euler( 
+void test_calc_alpha0_equivalent_euler(
     ActionModelLPFTypes::Type iam_type,
     DifferentialActionModelTypes::Type dam_type,
     PinocchioReferenceTypes::Type ref_type = PinocchioReferenceTypes::LOCAL,
-    ContactModelMaskTypes::Type mask_type = ContactModelMaskTypes::Z){
-    
+    ContactModelMaskTypes::Type mask_type = ContactModelMaskTypes::Z) {
   // Create IAM LPF
   ActionModelLPFFactory factory_iam;
   const boost::shared_ptr<sobec::IntegratedActionModelLPF>& modelLPF =
       factory_iam.create(iam_type, dam_type, ref_type, mask_type);
-  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataLPF = modelLPF->createData();
+  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataLPF =
+      modelLPF->createData();
 
   // Create IAM Euler from DAM and iamLPF.dt (with cost residual)
   DifferentialActionModelFactory factory_dam;
-  boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> dam = 
+  boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> dam =
       factory_dam.create(dam_type, ref_type, mask_type);
-  boost::shared_ptr<crocoddyl::IntegratedActionModelEuler> modelEuler = 
-    boost::make_shared<crocoddyl::IntegratedActionModelEuler>(dam, modelLPF->get_dt(), true);
-  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataEuler = modelEuler->createData();
+  boost::shared_ptr<crocoddyl::IntegratedActionModelEuler> modelEuler =
+      boost::make_shared<crocoddyl::IntegratedActionModelEuler>(
+          dam, modelLPF->get_dt(), true);
+  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataEuler =
+      modelEuler->createData();
 
   // Generating random values for the state and control
   std::size_t nx = modelEuler->get_state()->get_nx();
   std::size_t ndx = modelEuler->get_state()->get_ndx();
   std::size_t nv = modelEuler->get_state()->get_nv();
   // std::size_t nq = nx - nv;
-  std::size_t ntau = boost::static_pointer_cast<sobec::IntegratedActionModelLPF>(modelLPF)->get_ntau();
+  std::size_t ntau =
+      boost::static_pointer_cast<sobec::IntegratedActionModelLPF>(modelLPF)
+          ->get_ntau();
   const Eigen::VectorXd y = modelLPF->get_state()->rand();
   const Eigen::VectorXd& w = Eigen::VectorXd::Random(modelLPF->get_nw());
   const Eigen::VectorXd x = y.head(nx);
   const Eigen::VectorXd tau = y.tail(ntau);
   // Checking the partial derivatives against NumDiff
   double tol = 1e-6;
-  // Computing the action 
+  // Computing the action
   modelLPF->calc(dataLPF, y, w);
   modelEuler->calc(dataEuler, x, tau);
   // Test perfect actuation and state integration
@@ -199,33 +201,38 @@ void test_calc_alpha0_equivalent_euler(
   BOOST_CHECK((dataLPF->xnext.head(nx) - dataEuler->xnext).isZero(tol));
 }
 
-
-void test_calc_NONE_equivalent_euler( 
+void test_calc_NONE_equivalent_euler(
     ActionModelLPFTypes::Type iam_type,
     DifferentialActionModelTypes::Type dam_type,
     PinocchioReferenceTypes::Type ref_type = PinocchioReferenceTypes::LOCAL,
-    ContactModelMaskTypes::Type mask_type = ContactModelMaskTypes::Z){
-    
+    ContactModelMaskTypes::Type mask_type = ContactModelMaskTypes::Z) {
   // Create IAM LPF
   ActionModelLPFFactory factory_iam;
   const boost::shared_ptr<sobec::IntegratedActionModelLPF>& modelLPF =
       factory_iam.create(iam_type, dam_type, ref_type, mask_type);
-  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataLPF = modelLPF->createData();
+  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataLPF =
+      modelLPF->createData();
 
   // Create IAM Euler from DAM and iamLPF.dt (with cost residual)
   DifferentialActionModelFactory factory_dam;
-  boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> dam = 
+  boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> dam =
       factory_dam.create(dam_type, ref_type, mask_type);
-  boost::shared_ptr<crocoddyl::IntegratedActionModelEuler> modelEuler = 
-    boost::make_shared<crocoddyl::IntegratedActionModelEuler>(dam, modelLPF->get_dt(), true);
-  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataEuler = modelEuler->createData();
+  boost::shared_ptr<crocoddyl::IntegratedActionModelEuler> modelEuler =
+      boost::make_shared<crocoddyl::IntegratedActionModelEuler>(
+          dam, modelLPF->get_dt(), true);
+  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataEuler =
+      modelEuler->createData();
 
   // Generating random values for the state and control
   std::size_t nx = modelEuler->get_state()->get_nx();
   std::size_t ndx = modelEuler->get_state()->get_ndx();
   std::size_t nv = modelEuler->get_state()->get_nv();
-  std::size_t ntau = boost::static_pointer_cast<sobec::IntegratedActionModelLPF>(modelLPF)->get_ntau();
-  std::size_t ntau_state = boost::static_pointer_cast<sobec::StateLPF>(modelLPF->get_state())->get_ntau();
+  std::size_t ntau =
+      boost::static_pointer_cast<sobec::IntegratedActionModelLPF>(modelLPF)
+          ->get_ntau();
+  std::size_t ntau_state =
+      boost::static_pointer_cast<sobec::StateLPF>(modelLPF->get_state())
+          ->get_ntau();
   BOOST_CHECK(ntau == 0);
   BOOST_CHECK(ntau_state == 0);
   const std::vector<int>& lpf_torque_ids = modelLPF->get_lpf_torque_ids();
@@ -236,52 +243,55 @@ void test_calc_NONE_equivalent_euler(
   BOOST_CHECK(w.size() == modelEuler->get_nu());
   // Checking the partial derivatives against NumDiff
   double tol = 1e-6;
-  // Computing the action 
+  // Computing the action
   modelLPF->calc(dataLPF, y, w);
   modelEuler->calc(dataEuler, y, w);
   // Test perfect actuation and state integration
   BOOST_CHECK((dataLPF->xnext - dataEuler->xnext).isZero(tol));
 }
 
-
-void test_calcDiff_explicit_equivalent_euler( 
+void test_calcDiff_explicit_equivalent_euler(
     ActionModelLPFTypes::Type iam_type,
     DifferentialActionModelTypes::Type dam_type,
     PinocchioReferenceTypes::Type ref_type = PinocchioReferenceTypes::LOCAL,
-    ContactModelMaskTypes::Type mask_type = ContactModelMaskTypes::Z){
-    
+    ContactModelMaskTypes::Type mask_type = ContactModelMaskTypes::Z) {
   // Create IAM LPF
   ActionModelLPFFactory factory_iam;
   const boost::shared_ptr<sobec::IntegratedActionModelLPF>& modelLPF =
       factory_iam.create(iam_type, dam_type, ref_type, mask_type);
-  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataLPF = modelLPF->createData();
+  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataLPF =
+      modelLPF->createData();
 
   // Create IAM Euler from DAM and iamLPF.dt (with cost residual)
   DifferentialActionModelFactory factory_dam;
-  boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> dam = 
+  boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> dam =
       factory_dam.create(dam_type, ref_type, mask_type);
-  boost::shared_ptr<crocoddyl::IntegratedActionModelEuler> modelEuler = 
-    boost::make_shared<crocoddyl::IntegratedActionModelEuler>(dam, modelLPF->get_dt(), true);
-  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataEuler = modelEuler->createData();
+  boost::shared_ptr<crocoddyl::IntegratedActionModelEuler> modelEuler =
+      boost::make_shared<crocoddyl::IntegratedActionModelEuler>(
+          dam, modelLPF->get_dt(), true);
+  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataEuler =
+      modelEuler->createData();
 
   // Generating random values for the state and control
   std::size_t nx = modelEuler->get_state()->get_nx();
   std::size_t ndx = modelEuler->get_state()->get_ndx();
   std::size_t nv = modelEuler->get_state()->get_nv();
-  std::size_t ntau = boost::static_pointer_cast<sobec::IntegratedActionModelLPF>(modelLPF)->get_ntau();
+  std::size_t ntau =
+      boost::static_pointer_cast<sobec::IntegratedActionModelLPF>(modelLPF)
+          ->get_ntau();
   std::size_t nu = modelEuler->get_nu();
   const Eigen::VectorXd y = modelLPF->get_state()->rand();
   const Eigen::VectorXd& w = Eigen::VectorXd::Random(modelLPF->get_nw());
   const Eigen::VectorXd x = y.head(nx);
-  Eigen::VectorXd tau = w; 
+  Eigen::VectorXd tau = w;
   const std::vector<int>& lpf_torque_ids = modelLPF->get_lpf_torque_ids();
-  for(std::size_t i=0; i<lpf_torque_ids.size();i++){
+  for (std::size_t i = 0; i < lpf_torque_ids.size(); i++) {
     tau(lpf_torque_ids[i]) = y.tail(ntau)[i];
   }
   // Checking the partial derivatives against NumDiff
   double tol = 1e-3;
 
-  // Computing the action 
+  // Computing the action
   modelLPF->calc(dataLPF, y, w);
   modelEuler->calc(dataEuler, x, tau);
 
@@ -289,29 +299,31 @@ void test_calcDiff_explicit_equivalent_euler(
   modelLPF->calcDiff(dataLPF, y, w);
   modelEuler->calcDiff(dataEuler, x, tau);
 
-  // Size varying stuff  
+  // Size varying stuff
   const Eigen::MatrixXd& Fu_LPF = dataLPF->Fx.topRightCorner(ndx, ntau);
   const Eigen::MatrixXd& Lu_LPF = dataLPF->Lx.tail(ntau);
   const Eigen::MatrixXd& Lxu_LPF = dataLPF->Lxx.topRightCorner(ndx, ntau);
   const Eigen::MatrixXd& Luu_LPF = dataLPF->Lxx.bottomRightCorner(ntau, ntau);
-  for(std::size_t i=0; i<lpf_torque_ids.size();i++){
-    BOOST_CHECK((Fu_LPF.col(i) - dataEuler->Fu.col(lpf_torque_ids[i])).isZero(tol));
+  for (std::size_t i = 0; i < lpf_torque_ids.size(); i++) {
+    BOOST_CHECK(
+        (Fu_LPF.col(i) - dataEuler->Fu.col(lpf_torque_ids[i])).isZero(tol));
     BOOST_CHECK((Lu_LPF(i) - dataEuler->Lu(lpf_torque_ids[i])) <= tol);
-    BOOST_CHECK((Lxu_LPF.col(i) - dataEuler->Lxu.col(lpf_torque_ids[i])).isZero(tol));
+    BOOST_CHECK(
+        (Lxu_LPF.col(i) - dataEuler->Lxu.col(lpf_torque_ids[i])).isZero(tol));
   }
   // Fixed size stuff
   const Eigen::MatrixXd& Fx_LPF = dataLPF->Fx.topLeftCorner(ndx, ndx);
   const Eigen::MatrixXd& Lx_LPF = dataLPF->Lx.head(ndx);
   const Eigen::MatrixXd& Lxx_LPF = dataLPF->Lxx.topLeftCorner(ndx, ndx);
-  if(!  (Lxx_LPF - dataEuler->Lxx).isZero(tol) ){
+  if (!(Lxx_LPF - dataEuler->Lxx).isZero(tol)) {
     std::cout << Lxx_LPF - dataEuler->Lxx << std::endl;
   }
-  // Testing the partials w.r.t. u match blocks in partial w.r.t. augmented state y
+  // Testing the partials w.r.t. u match blocks in partial w.r.t. augmented
+  // state y
   BOOST_CHECK((Fx_LPF - dataEuler->Fx).isZero(tol));
   BOOST_CHECK((Lx_LPF - dataEuler->Lx).isZero(tol));
   BOOST_CHECK((Lxx_LPF - dataEuler->Lxx).isZero(tol));
 }
-
 
 //----------------------------------------------------------------------------//
 
@@ -339,15 +351,22 @@ void register_action_model_unit_tests(
                                       dam_type, ref_type, mask_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_returns_a_cost, iam_type,
                                       dam_type, ref_type, mask_type)));
-  ts->add(BOOST_TEST_CASE(boost::bind(&test_partial_derivatives_action_model,
+  ts->add(
+      BOOST_TEST_CASE(boost::bind(&test_partial_derivatives_action_model,
                                   iam_type, dam_type, ref_type, mask_type)));
-  if(iam_type == ActionModelLPFTypes::Type::IntegratedActionModelLPF_alpha0){
-    ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_alpha0_equivalent_euler, iam_type, dam_type, ref_type, mask_type)));
+  if (iam_type == ActionModelLPFTypes::Type::IntegratedActionModelLPF_alpha0) {
+    ts->add(
+        BOOST_TEST_CASE(boost::bind(&test_calc_alpha0_equivalent_euler,
+                                    iam_type, dam_type, ref_type, mask_type)));
   }
-  if(iam_type == ActionModelLPFTypes::Type::IntegratedActionModelLPF_NONE){
-    ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_NONE_equivalent_euler, iam_type, dam_type, ref_type, mask_type)));
+  if (iam_type == ActionModelLPFTypes::Type::IntegratedActionModelLPF_NONE) {
+    ts->add(
+        BOOST_TEST_CASE(boost::bind(&test_calc_NONE_equivalent_euler, iam_type,
+                                    dam_type, ref_type, mask_type)));
   }
-  ts->add(BOOST_TEST_CASE(boost::bind(&test_calcDiff_explicit_equivalent_euler, iam_type, dam_type, ref_type, mask_type)));
+  ts->add(
+      BOOST_TEST_CASE(boost::bind(&test_calcDiff_explicit_equivalent_euler,
+                                  iam_type, dam_type, ref_type, mask_type)));
   framework::master_test_suite().add(ts);
 }
 

--- a/tests/test_lpf.cpp
+++ b/tests/test_lpf.cpp
@@ -159,7 +159,7 @@ void test_partial_derivatives_action_model(
 
 
 
-void test_calc_equivalent_euler( 
+void test_calc_alpha0_equivalent_euler( 
     ActionModelLPFTypes::Type iam_type,
     DifferentialActionModelTypes::Type dam_type,
     PinocchioReferenceTypes::Type ref_type = PinocchioReferenceTypes::LOCAL,
@@ -180,41 +180,136 @@ void test_calc_equivalent_euler(
   const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataEuler = modelEuler->createData();
 
   // Generating random values for the state and control
-  Eigen::VectorXd y = modelLPF->get_state()->rand();
-  const Eigen::VectorXd& w = Eigen::VectorXd::Random(modelLPF->get_nw());
   std::size_t nx = modelEuler->get_state()->get_nx();
   std::size_t ndx = modelEuler->get_state()->get_ndx();
   std::size_t nv = modelEuler->get_state()->get_nv();
+  // std::size_t nq = nx - nv;
+  std::size_t ntau = boost::static_pointer_cast<sobec::IntegratedActionModelLPF>(modelLPF)->get_ntau();
+  const Eigen::VectorXd y = modelLPF->get_state()->rand();
+  const Eigen::VectorXd& w = Eigen::VectorXd::Random(modelLPF->get_nw());
+  const Eigen::VectorXd x = y.head(nx);
+  const Eigen::VectorXd tau = y.tail(ntau);
   // Checking the partial derivatives against NumDiff
-  double tol = 1e-2;
+  double tol = 1e-6;
+  // Computing the action 
+  modelLPF->calc(dataLPF, y, w);
+  modelEuler->calc(dataEuler, x, tau);
+  // Test perfect actuation and state integration
+  BOOST_CHECK((dataLPF->xnext.tail(ntau) - w).isZero(tol));
+  BOOST_CHECK((dataLPF->xnext.head(nx) - dataEuler->xnext).isZero(tol));
+}
+
+
+void test_calc_NONE_equivalent_euler( 
+    ActionModelLPFTypes::Type iam_type,
+    DifferentialActionModelTypes::Type dam_type,
+    PinocchioReferenceTypes::Type ref_type = PinocchioReferenceTypes::LOCAL,
+    ContactModelMaskTypes::Type mask_type = ContactModelMaskTypes::Z){
+    
+  // Create IAM LPF
+  ActionModelLPFFactory factory_iam;
+  const boost::shared_ptr<sobec::IntegratedActionModelLPF>& modelLPF =
+      factory_iam.create(iam_type, dam_type, ref_type, mask_type);
+  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataLPF = modelLPF->createData();
+
+  // Create IAM Euler from DAM and iamLPF.dt (with cost residual)
+  DifferentialActionModelFactory factory_dam;
+  boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> dam = 
+      factory_dam.create(dam_type, ref_type, mask_type);
+  boost::shared_ptr<crocoddyl::IntegratedActionModelEuler> modelEuler = 
+    boost::make_shared<crocoddyl::IntegratedActionModelEuler>(dam, modelLPF->get_dt(), true);
+  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataEuler = modelEuler->createData();
+
+  // Generating random values for the state and control
+  std::size_t nx = modelEuler->get_state()->get_nx();
+  std::size_t ndx = modelEuler->get_state()->get_ndx();
+  std::size_t nv = modelEuler->get_state()->get_nv();
+  std::size_t ntau = boost::static_pointer_cast<sobec::IntegratedActionModelLPF>(modelLPF)->get_ntau();
+  std::size_t ntau_state = boost::static_pointer_cast<sobec::StateLPF>(modelLPF->get_state())->get_ntau();
+  BOOST_CHECK(ntau == 0);
+  BOOST_CHECK(ntau_state == 0);
+  const std::vector<int>& lpf_torque_ids = modelLPF->get_lpf_torque_ids();
+  BOOST_CHECK(lpf_torque_ids.size() == 0);
+  const Eigen::VectorXd y = modelLPF->get_state()->rand();
+  BOOST_CHECK(y.size() == nx);
+  const Eigen::VectorXd& w = Eigen::VectorXd::Random(modelLPF->get_nw());
+  BOOST_CHECK(w.size() == modelEuler->get_nu());
+  // Checking the partial derivatives against NumDiff
+  double tol = 1e-6;
+  // Computing the action 
+  modelLPF->calc(dataLPF, y, w);
+  modelEuler->calc(dataEuler, y, w);
+  // Test perfect actuation and state integration
+  BOOST_CHECK((dataLPF->xnext - dataEuler->xnext).isZero(tol));
+}
+
+
+void test_calcDiff_explicit_equivalent_euler( 
+    ActionModelLPFTypes::Type iam_type,
+    DifferentialActionModelTypes::Type dam_type,
+    PinocchioReferenceTypes::Type ref_type = PinocchioReferenceTypes::LOCAL,
+    ContactModelMaskTypes::Type mask_type = ContactModelMaskTypes::Z){
+    
+  // Create IAM LPF
+  ActionModelLPFFactory factory_iam;
+  const boost::shared_ptr<sobec::IntegratedActionModelLPF>& modelLPF =
+      factory_iam.create(iam_type, dam_type, ref_type, mask_type);
+  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataLPF = modelLPF->createData();
+
+  // Create IAM Euler from DAM and iamLPF.dt (with cost residual)
+  DifferentialActionModelFactory factory_dam;
+  boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> dam = 
+      factory_dam.create(dam_type, ref_type, mask_type);
+  boost::shared_ptr<crocoddyl::IntegratedActionModelEuler> modelEuler = 
+    boost::make_shared<crocoddyl::IntegratedActionModelEuler>(dam, modelLPF->get_dt(), true);
+  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& dataEuler = modelEuler->createData();
+
+  // Generating random values for the state and control
+  std::size_t nx = modelEuler->get_state()->get_nx();
+  std::size_t ndx = modelEuler->get_state()->get_ndx();
+  std::size_t nv = modelEuler->get_state()->get_nv();
+  std::size_t ntau = boost::static_pointer_cast<sobec::IntegratedActionModelLPF>(modelLPF)->get_ntau();
+  std::size_t nu = modelEuler->get_nu();
+  const Eigen::VectorXd y = modelLPF->get_state()->rand();
+  const Eigen::VectorXd& w = Eigen::VectorXd::Random(modelLPF->get_nw());
+  const Eigen::VectorXd x = y.head(nx);
+  Eigen::VectorXd tau = w; 
+  const std::vector<int>& lpf_torque_ids = modelLPF->get_lpf_torque_ids();
+  for(std::size_t i=0; i<lpf_torque_ids.size();i++){
+    tau(lpf_torque_ids[i]) = y.tail(ntau)[i];
+  }
+  // Checking the partial derivatives against NumDiff
+  double tol = 1e-3;
 
   // Computing the action 
   modelLPF->calc(dataLPF, y, w);
-  if(!(dataLPF->xnext.tail(nv) - w).isZero(tol)){
-    std::cout << " lpf " << std::endl;
-    std::cout << dataLPF->xnext.tail(nv) << std::endl;
-    std::cout << w << std::endl;
-    // std::cout << dataEuler->Lxx << std::endl;
-  }
-  BOOST_CHECK((dataLPF->xnext.tail(nv) - w).isZero(tol));
-  modelEuler->calc(dataEuler, y.head(nx), w);
-  BOOST_CHECK((dataLPF->xnext.head(nx) - dataEuler->xnext).isZero(tol));
+  modelEuler->calc(dataEuler, x, tau);
+
   // Computing the derivatives
   modelLPF->calcDiff(dataLPF, y, w);
-  modelEuler->calcDiff(dataEuler, y.head(nx), w);
-  BOOST_CHECK((dataLPF->Fx.topLeftCorner(nv, ndx) - dataEuler->Fx).isZero(tol));
-  BOOST_CHECK((dataLPF->Fu.topLeftCorner(nv, ndx) - dataEuler->Fu).isZero(tol));
-  BOOST_CHECK((dataLPF->Lx.head(nx) - dataEuler->Lx).isZero(tol));
-  BOOST_CHECK((dataLPF->Lu.head(nv) - dataEuler->Lu).isZero(tol));
-  BOOST_CHECK((dataLPF->Lxx.topLeftCorner(ndx, ndx) - dataEuler->Lxx).isZero(tol));
-  // if(!(dataLPF->Lxx.topLeftCorner(ndx, nv) - dataEuler->Lxx).isZero(tol)){
-  //   std::cout << " lpf " << std::endl;
-  //   std::cout << dataLPF->Lxx.topLeftCorner(ndx, ndx) << std::endl;
-  //   std::cout << " euler " << std::endl;
-  //   std::cout << dataEuler->Lxx << std::endl;
-  // }
-  BOOST_CHECK((dataLPF->Lxu.topLeftCorner(ndx, nv) - dataEuler->Lxu).isZero(tol));
-  BOOST_CHECK((dataLPF->Luu.topLeftCorner(nv,nv) - dataEuler->Luu).isZero(tol));
+  modelEuler->calcDiff(dataEuler, x, tau);
+
+  // Size varying stuff  
+  const Eigen::MatrixXd& Fu_LPF = dataLPF->Fx.topRightCorner(ndx, ntau);
+  const Eigen::MatrixXd& Lu_LPF = dataLPF->Lx.tail(ntau);
+  const Eigen::MatrixXd& Lxu_LPF = dataLPF->Lxx.topRightCorner(ndx, ntau);
+  const Eigen::MatrixXd& Luu_LPF = dataLPF->Lxx.bottomRightCorner(ntau, ntau);
+  for(std::size_t i=0; i<lpf_torque_ids.size();i++){
+    BOOST_CHECK((Fu_LPF.col(i) - dataEuler->Fu.col(lpf_torque_ids[i])).isZero(tol));
+    BOOST_CHECK((Lu_LPF(i) - dataEuler->Lu(lpf_torque_ids[i])) <= tol);
+    BOOST_CHECK((Lxu_LPF.col(i) - dataEuler->Lxu.col(lpf_torque_ids[i])).isZero(tol));
+  }
+  // Fixed size stuff
+  const Eigen::MatrixXd& Fx_LPF = dataLPF->Fx.topLeftCorner(ndx, ndx);
+  const Eigen::MatrixXd& Lx_LPF = dataLPF->Lx.head(ndx);
+  const Eigen::MatrixXd& Lxx_LPF = dataLPF->Lxx.topLeftCorner(ndx, ndx);
+  if(!  (Lxx_LPF - dataEuler->Lxx).isZero(tol) ){
+    std::cout << Lxx_LPF - dataEuler->Lxx << std::endl;
+  }
+  // Testing the partials w.r.t. u match blocks in partial w.r.t. augmented state y
+  BOOST_CHECK((Fx_LPF - dataEuler->Fx).isZero(tol));
+  BOOST_CHECK((Lx_LPF - dataEuler->Lx).isZero(tol));
+  BOOST_CHECK((Lxx_LPF - dataEuler->Lxx).isZero(tol));
 }
 
 
@@ -244,13 +339,15 @@ void register_action_model_unit_tests(
                                       dam_type, ref_type, mask_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_returns_a_cost, iam_type,
                                       dam_type, ref_type, mask_type)));
-  ts->add(
-      BOOST_TEST_CASE(boost::bind(&test_partial_derivatives_action_model,
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_partial_derivatives_action_model,
                                   iam_type, dam_type, ref_type, mask_type)));
-  if(iam_type == ActionModelLPFTypes::Type::IntegratedActionModelLPF_alpha0 ||
-     iam_type == ActionModelLPFTypes::Type::IntegratedActionModelLPF_NONE){
-    ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_equivalent_euler, iam_type, dam_type, ref_type, mask_type)));
+  if(iam_type == ActionModelLPFTypes::Type::IntegratedActionModelLPF_alpha0){
+    ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_alpha0_equivalent_euler, iam_type, dam_type, ref_type, mask_type)));
   }
+  if(iam_type == ActionModelLPFTypes::Type::IntegratedActionModelLPF_NONE){
+    ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_NONE_equivalent_euler, iam_type, dam_type, ref_type, mask_type)));
+  }
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_calcDiff_explicit_equivalent_euler, iam_type, dam_type, ref_type, mask_type)));
   framework::master_test_suite().add(ts);
 }
 


### PR DESCRIPTION
- fix some warnings
- add unittests for equivalence of `calc` and `calcDiff` between `sobec::IntegratedActionModelLPF` and `crocoddyl::IntegratedActionModelEuler` when `alpha=0` (i.e. infinite cut-off frequency, perfect torque actuation) and when the dimension low-pass filtered joints is 0