### PR TITLE
Updates to Python bindings: std::vector, stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ set(PROJECT_URL https://github.com/${PROJECT_NAMESPACE}/${PROJECT_NAME})
 option(BUILD_PYTHON_INTERFACE "Build the python binding" ON)
 option(BUILD_PY2CPP_INTERFACE "Build the py2cpp library" OFF)
 option(SUFFIX_SO_VERSION "Suffix library name with its version" ON)
+option(GENERATE_PYTHON_STUBS
+       "Generate the Python stubs associated to the Python library" OFF)
 
 # Project configuration
 set(PROJECT_USE_CMAKE_EXPORT TRUE)
@@ -35,6 +37,7 @@ endif()
 # JRL-cmakemodule setup
 include("${JRL_CMAKE_MODULES}/base.cmake")
 include("${JRL_CMAKE_MODULES}/boost.cmake")
+include("${JRL_CMAKE_MODULES}/stubs.cmake")
 
 # Project definition
 compute_project_args(PROJECT_ARGS LANGUAGES CXX)

--- a/include/sobec/crocomplements/lowpassfilter/action.hpp
+++ b/include/sobec/crocomplements/lowpassfilter/action.hpp
@@ -162,7 +162,8 @@ class IntegratedActionModelLPFTpl : public ActionModelAbstractTpl<_Scalar> {
 };
 
 template <typename _Scalar>
-struct IntegratedActionDataLPFTpl : public ActionDataAbstractTpl<_Scalar> {
+class IntegratedActionDataLPFTpl : public ActionDataAbstractTpl<_Scalar> {
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   typedef _Scalar Scalar;

--- a/include/sobec/crocomplements/lowpassfilter/action.hpp
+++ b/include/sobec/crocomplements/lowpassfilter/action.hpp
@@ -163,7 +163,7 @@ class IntegratedActionModelLPFTpl : public ActionModelAbstractTpl<_Scalar> {
 
 template <typename _Scalar>
 class IntegratedActionDataLPFTpl : public ActionDataAbstractTpl<_Scalar> {
-public:
+ public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   typedef _Scalar Scalar;

--- a/include/sobec/crocomplements/lowpassfilter/action.hpp
+++ b/include/sobec/crocomplements/lowpassfilter/action.hpp
@@ -70,8 +70,8 @@ class IntegratedActionModelLPFTpl : public ActionModelAbstractTpl<_Scalar> {
   virtual void quasiStatic(const boost::shared_ptr<ActionDataAbstract>& data,
                            Eigen::Ref<VectorXs> u,
                            const Eigen::Ref<const VectorXs>& x,
-                           const std::size_t& maxiter = 100,
-                           const Scalar& tol = Scalar(1e-9));
+                           const std::size_t maxiter = 100,
+                           const Scalar tol = Scalar(1e-9));
 
   const boost::shared_ptr<DifferentialActionModelAbstract>& get_differential()
       const;

--- a/include/sobec/crocomplements/lowpassfilter/action.hxx
+++ b/include/sobec/crocomplements/lowpassfilter/action.hxx
@@ -914,8 +914,8 @@ void IntegratedActionModelLPFTpl<Scalar>::set_control_lim_cost(
 template <typename Scalar>
 void IntegratedActionModelLPFTpl<Scalar>::quasiStatic(
     const boost::shared_ptr<ActionDataAbstract>& data, Eigen::Ref<VectorXs> u,
-    const Eigen::Ref<const VectorXs>& x, const std::size_t& maxiter,
-    const Scalar& tol) {
+    const Eigen::Ref<const VectorXs>& x, const std::size_t maxiter,
+    const Scalar tol) {
   if (static_cast<std::size_t>(u.size()) != nu_) {
     throw_pretty("Invalid argument: "
                  << "u has wrong dimension (it should be " +

--- a/include/sobec/fwd.hpp
+++ b/include/sobec/fwd.hpp
@@ -196,7 +196,7 @@ template <typename Scalar>
 class ContactModel3DTpl;
 typedef ContactModel3DTpl<double> ContactModel3D;
 template <typename Scalar>
-class ContactData3DTpl;
+struct ContactData3DTpl;
 typedef ContactData3DTpl<double> ContactData3D;
 
 // contact 1D
@@ -204,7 +204,7 @@ template <typename Scalar>
 class ContactModel1DTpl;
 typedef ContactModel1DTpl<double> ContactModel1D;
 template <typename Scalar>
-class ContactData1DTpl;
+struct ContactData1DTpl;
 typedef ContactData1DTpl<double> ContactData1D;
 
 // multiple contacts

--- a/include/sobec/fwd.hpp
+++ b/include/sobec/fwd.hpp
@@ -223,13 +223,7 @@ template <typename Scalar>
 class ResidualModelContactForceTpl;
 typedef ResidualModelContactForceTpl<double> ResidualModelContactForce;
 
-enum ContactType {
-  ContactUndefined,
-  Contact1D,
-  Contact2D,
-  Contact3D,
-  Contact6D
-};
+using crocoddyl::ContactType;
 
 }  // namespace newcontacts
 }  // namespace sobec

--- a/include/sobec/python.hpp
+++ b/include/sobec/python.hpp
@@ -1,7 +1,7 @@
 #ifndef __sobec_python__
 #define __sobec_python__
 
-#include <boost/python.hpp>
+#include <eigenpy/eigenpy.hpp>
 #include <pinocchio/fwd.hpp>
 
 namespace sobec {

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -48,6 +48,11 @@ set(${PY_NAME}_PYTHON
     # talos_low.py
 )
 
+if(GENERATE_PYTHON_STUBS)
+  load_stubgen()
+  generate_stubs(${CMAKE_CURRENT_BINARY_DIR} ${PROJECT_NAME} ${PYTHON_SITELIB})
+endif(GENERATE_PYTHON_STUBS)
+
 foreach(python ${${PY_NAME}_PYTHON})
   python_install_on_site(${PY_NAME} ${python})
 endforeach()

--- a/python/crocomplements/activation-quad-ref.cpp
+++ b/python/crocomplements/activation-quad-ref.cpp
@@ -6,10 +6,10 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "sobec/crocomplements/activation-quad-ref.hpp"
+
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!
-
-#include "sobec/crocomplements/activation-quad-ref.hpp"
 
 namespace sobec {
 namespace python {

--- a/python/crocomplements/activation-quad-ref.cpp
+++ b/python/crocomplements/activation-quad-ref.cpp
@@ -6,8 +6,7 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
+#include <eigenpy/eigenpy.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!
 // #include "python/crocoddyl/core/core.hpp"
 // #include "python/crocoddyl/core/activation-base.hpp"

--- a/python/crocomplements/activation-quad-ref.cpp
+++ b/python/crocomplements/activation-quad-ref.cpp
@@ -8,9 +8,6 @@
 
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!
-// #include "python/crocoddyl/core/core.hpp"
-// #include "python/crocoddyl/core/activation-base.hpp"
-#include <crocoddyl/core/activation-base.hpp>
 
 #include "sobec/crocomplements/activation-quad-ref.hpp"
 

--- a/python/crocomplements/activation-quad-ref.cpp
+++ b/python/crocomplements/activation-quad-ref.cpp
@@ -6,7 +6,6 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <pinocchio/fwd.hpp>
 #include <boost/python.hpp>
 #include <boost/python/enum.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!

--- a/python/crocomplements/activation-quad-ref.cpp
+++ b/python/crocomplements/activation-quad-ref.cpp
@@ -6,6 +6,7 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
+#include <pinocchio/fwd.hpp>
 #include <boost/python.hpp>
 #include <boost/python/enum.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!

--- a/python/crocomplements/contact/contact-force.cpp
+++ b/python/crocomplements/contact/contact-force.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/contact/contact-force.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 
 namespace sobec {

--- a/python/crocomplements/contact/contact-fwddyn.cpp
+++ b/python/crocomplements/contact/contact-fwddyn.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/contact/contact-fwddyn.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 
 namespace sobec {

--- a/python/crocomplements/contact/contact1d.cpp
+++ b/python/crocomplements/contact/contact1d.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/contact/contact1d.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 
 namespace sobec {

--- a/python/crocomplements/contact/contact3d.cpp
+++ b/python/crocomplements/contact/contact3d.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/contact/contact3d.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 
 namespace sobec {

--- a/python/crocomplements/contact/contact6d.cpp
+++ b/python/crocomplements/contact/contact6d.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/contact/contact6d.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 
 namespace sobec {

--- a/python/crocomplements/contact/multiple-contacts.cpp
+++ b/python/crocomplements/contact/multiple-contacts.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/contact/multiple-contacts.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 
 namespace sobec {

--- a/python/crocomplements/lowpassfilter/action.cpp
+++ b/python/crocomplements/lowpassfilter/action.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/lowpassfilter/action.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <crocoddyl/core/action-base.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/fwd.hpp>  // to avoid compilation error (https://github.com/loco-3d/crocoddyl/issues/205)

--- a/python/crocomplements/lowpassfilter/state.cpp
+++ b/python/crocomplements/lowpassfilter/state.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/lowpassfilter/state.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 
 namespace sobec {

--- a/python/crocomplements/residual-2D-surface.cpp
+++ b/python/crocomplements/residual-2D-surface.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/residual-2D-surface.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!
 

--- a/python/crocomplements/residual-center-of-friction.cpp
+++ b/python/crocomplements/residual-center-of-friction.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/residual-center-of-friction.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!
 

--- a/python/crocomplements/residual-com-velocity.cpp
+++ b/python/crocomplements/residual-com-velocity.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/residual-com-velocity.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!
 

--- a/python/crocomplements/residual-cop.cpp
+++ b/python/crocomplements/residual-cop.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/residual-cop.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!
 

--- a/python/crocomplements/residual-dcm-position.cpp
+++ b/python/crocomplements/residual-dcm-position.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/residual-dcm-position.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!
 

--- a/python/crocomplements/residual-feet-collision.cpp
+++ b/python/crocomplements/residual-feet-collision.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/residual-feet-collision.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!
 

--- a/python/crocomplements/residual-fly-angle.cpp
+++ b/python/crocomplements/residual-fly-angle.cpp
@@ -81,7 +81,7 @@ void exposeResidualFlyAngle() {
                     &ResidualModelFlyAngle::setSlope,
                     "Set slope (ie altitude multiplicator)");
 
-  bp::register_ptr_to_python<boost::shared_ptr<ResidualModelFlyAngle> >();
+  bp::register_ptr_to_python<boost::shared_ptr<ResidualDataFlyAngle> >();
 
   bp::class_<ResidualDataFlyAngle, bp::bases<ResidualDataAbstract> >(
       "ResidualDataFlyAngle", "Data for vel collision residual.\n\n",

--- a/python/crocomplements/residual-fly-angle.cpp
+++ b/python/crocomplements/residual-fly-angle.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/residual-fly-angle.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!
 

--- a/python/crocomplements/residual-fly-high.cpp
+++ b/python/crocomplements/residual-fly-high.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/crocomplements/residual-fly-high.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!
 

--- a/python/crocomplements/residual-vel-collision.cpp
+++ b/python/crocomplements/residual-vel-collision.cpp
@@ -10,8 +10,6 @@
 
 #include "sobec/crocomplements/residual-vel-collision.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!
 

--- a/python/flexibility_compensation.cpp
+++ b/python/flexibility_compensation.cpp
@@ -2,10 +2,6 @@
 
 #include "sobec/fwd.hpp"
 // keep this line on top
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
-#include <boost/python/return_internal_reference.hpp>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <sobec/flexibility_compensation.hpp>
 

--- a/python/main.cpp
+++ b/python/main.cpp
@@ -5,7 +5,6 @@
 BOOST_PYTHON_MODULE(sobec_pywrap) {
   boost::python::import("pinocchio");
   boost::python::import("crocoddyl");
-  boost::python::import("pinocchio");
   // Enabling eigenpy support, i.e. numpy/eigen compatibility.
   eigenpy::enableEigenPy();
   ENABLE_SPECIFIC_MATRIX_TYPE(Eigen::VectorXi);

--- a/python/main.cpp
+++ b/python/main.cpp
@@ -3,11 +3,13 @@
 #include "sobec/python.hpp"
 
 BOOST_PYTHON_MODULE(sobec_pywrap) {
-  boost::python::import("pinocchio");
-  boost::python::import("crocoddyl");
+  namespace bp = boost::python;
+
+  bp::import("pinocchio");
+  bp::import("crocoddyl");
   // Enabling eigenpy support, i.e. numpy/eigen compatibility.
   eigenpy::enableEigenPy();
-  ENABLE_SPECIFIC_MATRIX_TYPE(Eigen::VectorXi);
+  eigenpy::enableEigenPySpecific<Eigen::VectorXi>();
   sobec::python::exposeStdContainers();
   sobec::python::exposeResidualVelCollision();
   sobec::python::exposeResidualCoMVelocity();

--- a/python/sobec/__init__.py
+++ b/python/sobec/__init__.py
@@ -1,39 +1,6 @@
 # flake8: noqa
 
-from .sobec_pywrap import (
-    ResidualModelCoMVelocity,
-    ResidualModelVelCollision,
-    ActivationModelQuadRef,
-    RobotDesigner,
-    HorizonManager,
-    ModelMaker,
-    Support,
-    Experiment,
-    ResidualModelCenterOfPressure,
-    ResidualModelFeetCollision,
-    ResidualModelFlyHigh,
-    ResidualModelFlyAngle,
-    ResidualModel2DSurface,
-    IntegratedActionModelLPF,
-    StateLPF,
-    ContactModel6D,
-    ContactModel3D,
-    ContactModel1D,
-    ContactModelMultiple,
-    DifferentialActionModelContactFwdDynamics,
-    ResidualModelContactForce,
-    WBC,
-    WBCHorizon,
-    FootTrajectory,
-    OCPRobotWrapper,
-    OCPWalkParams,
-    OCPWalk,
-    MPCWalkParams,
-    MPCWalk,
-    Flex,
-    computeWeightShareSmoothProfile,
-    LocomotionType,
-)
+from .sobec_pywrap import *
 
 from .repr_ocp import reprProblem
 from .viewer_multiple import GepettoGhostViewer

--- a/python/sobec/walk_without_think/yaml_params.py
+++ b/python/sobec/walk_without_think/yaml_params.py
@@ -52,8 +52,8 @@ def flattenDictArrayValues(paramsAsDict):
             todel.append(k)
         if isinstance(v, np.ndarray):
             paramsAsDict[k] = v.tolist()
-        elif isinstance(v, sobec.sobec_pywrap.StdVectorStdStringIndex_):
-            paramsAsDict[k] = [str(vi) for vi in v]
+        elif hasattr(v, "tolist"):
+            paramsAsDict[k] = v.tolist()
     for k in todel:
         del paramsAsDict[k]
 

--- a/python/std-containers.cpp
+++ b/python/std-containers.cpp
@@ -35,9 +35,8 @@ struct StdVectorPythonVisitor : pinocchio::python::StdVectorPythonVisitor<
 #endif
 
 void exposeStdContainers() {
-  StdVectorPythonVisitor<std::vector<std::string>>::expose(
-      "StdVectorStdStringIndex_");
-
+  typedef std::vector<std::string> std_vec_str_t;
+  StdVectorPythonVisitor<std_vec_str_t>::expose("StdVec_StdString");
   StdVectorPythonVisitor<std::vector<pinocchio::Force>>::expose(
       "StdVectorPinocchioForce_");
   StdVectorPythonVisitor<std::vector<std::vector<pinocchio::Force>>>::expose(

--- a/python/std-containers.cpp
+++ b/python/std-containers.cpp
@@ -6,45 +6,51 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <pinocchio/bindings/python/utils/std-map.hpp>
-#include <pinocchio/bindings/python/utils/std-vector.hpp>
-#include <pinocchio/fwd.hpp>
 #include <pinocchio/multibody/fwd.hpp>
 #include <pinocchio/spatial/force.hpp>
+#include <eigenpy/fwd.hpp>
+
+#if EIGENPY_VERSION_AT_LEAST(2,8,0)
+  #include <eigenpy/std-map.hpp>
+  #include <eigenpy/std-vector.hpp>
+#else
+  #include <pinocchio/bindings/python/utils/std-map.hpp>
+  #include <pinocchio/bindings/python/utils/std-vector.hpp>
+#endif
 
 namespace sobec {
 namespace python {
 
 namespace bp = boost::python;
-namespace pp = pinocchio::python;
+
+#if EIGENPY_VERSION_AT_LEAST(2,8,0)
+  using eigenpy::StdVectorPythonVisitor;
+#else
+  using pinocchio::python::StdVectorPythonVisitor;
+#endif
 
 void exposeStdContainers() {
-  pp::StdVectorPythonVisitor<pinocchio::FrameIndex>::expose(
-      "StdVectorPinocchioFrameIndex_");
+  StdVectorPythonVisitor<std::vector<std::string>>::expose(
+      "StdVectorStdStringIndex_");
 
-  pp::StdVectorPythonVisitor<std::string>::expose("StdVectorStdStringIndex_");
-
-  pp::StdVectorPythonVisitor<pinocchio::Force>::expose(
+  StdVectorPythonVisitor<std::vector<pinocchio::Force>>::expose(
       "StdVectorPinocchioForce_");
-  pp::StdVectorPythonVisitor<std::vector<pinocchio::Force>>::expose(
-      "StdVectorStdVectorPinocchioForce_");
+  StdVectorPythonVisitor<std::vector<std::vector<pinocchio::Force>>>::
+      expose("StdVectorStdVectorPinocchioForce_");
 
-  bp::class_<std::map<pinocchio::FrameIndex, pinocchio::FrameIndex>>(
+  using frame_frame_map_t = std::map<pinocchio::FrameIndex, pinocchio::FrameIndex>;
+  bp::class_<frame_frame_map_t>(
       "StdMapPinocchioFrameIndexToPinocchioFrameIndex_")
-      .def(bp::map_indexing_suite<
-           std::map<pinocchio::FrameIndex, pinocchio::FrameIndex>, true>())
-      // .def(pp::details::overload_base_get_item_for_std_map<std::map<pinocchio::FrameIndex,
+      .def(bp::map_indexing_suite<frame_frame_map_t, true>())
+      // .def(ep::details::overload_base_get_item_for_std_map<std::map<pinocchio::FrameIndex,
       // pinocchio::FrameIndex>>())
       ;
 
-  bp::class_<
-      std::pair<std::vector<Eigen::VectorXd>, std::vector<Eigen::VectorXd>>>(
-      "EigenVectorXd")
-      .def_readwrite("first", &std::pair<std::vector<Eigen::VectorXd>,
-                                         std::vector<Eigen::VectorXd>>::first)
-      .def_readwrite("second",
-                     &std::pair<std::vector<Eigen::VectorXd>,
-                                std::vector<Eigen::VectorXd>>::second);
+  using StdVecVectorXd = std::vector<Eigen::VectorXd>;
+  using pair_vec_vec_t = std::pair<StdVecVectorXd, StdVecVectorXd>;
+  bp::class_<pair_vec_vec_t>("StdPair_StdVector_EigenVectorXd")
+      .def_readwrite("first", &pair_vec_vec_t::first)
+      .def_readwrite("second", &pair_vec_vec_t::second);
 }
 
 }  // namespace python

--- a/python/std-containers.cpp
+++ b/python/std-containers.cpp
@@ -6,16 +6,16 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
+#include <eigenpy/fwd.hpp>
 #include <pinocchio/multibody/fwd.hpp>
 #include <pinocchio/spatial/force.hpp>
-#include <eigenpy/fwd.hpp>
 
-#if EIGENPY_VERSION_AT_LEAST(2,8,0)
-  #include <eigenpy/std-map.hpp>
-  #include <eigenpy/std-vector.hpp>
+#if EIGENPY_VERSION_AT_LEAST(2, 8, 0)
+#include <eigenpy/std-map.hpp>
+#include <eigenpy/std-vector.hpp>
 #else
-  #include <pinocchio/bindings/python/utils/std-map.hpp>
-  #include <pinocchio/bindings/python/utils/std-vector.hpp>
+#include <pinocchio/bindings/python/utils/std-map.hpp>
+#include <pinocchio/bindings/python/utils/std-vector.hpp>
 #endif
 
 namespace sobec {
@@ -23,10 +23,15 @@ namespace python {
 
 namespace bp = boost::python;
 
-#if EIGENPY_VERSION_AT_LEAST(2,8,0)
-  using eigenpy::StdVectorPythonVisitor;
+#if EIGENPY_VERSION_AT_LEAST(2, 8, 0)
+using eigenpy::StdVectorPythonVisitor;
+#elif PINOCCHIO_VERSION_AT_LEAST(2, 9, 2)
+using pinocchio::python::StdVectorPythonVisitor;
 #else
-  using pinocchio::python::StdVectorPythonVisitor;
+// the template parameter used to be the value_type.
+template <typename vector_type>
+struct StdVectorPythonVisitor : pinocchio::python::StdVectorPythonVisitor<
+                                    typename vector_type::value_type> {};
 #endif
 
 void exposeStdContainers() {
@@ -35,10 +40,11 @@ void exposeStdContainers() {
 
   StdVectorPythonVisitor<std::vector<pinocchio::Force>>::expose(
       "StdVectorPinocchioForce_");
-  StdVectorPythonVisitor<std::vector<std::vector<pinocchio::Force>>>::
-      expose("StdVectorStdVectorPinocchioForce_");
+  StdVectorPythonVisitor<std::vector<std::vector<pinocchio::Force>>>::expose(
+      "StdVectorStdVectorPinocchioForce_");
 
-  using frame_frame_map_t = std::map<pinocchio::FrameIndex, pinocchio::FrameIndex>;
+  using frame_frame_map_t =
+      std::map<pinocchio::FrameIndex, pinocchio::FrameIndex>;
   bp::class_<frame_frame_map_t>(
       "StdMapPinocchioFrameIndexToPinocchioFrameIndex_")
       .def(bp::map_indexing_suite<frame_frame_map_t, true>())

--- a/python/walk-with-traj/designer.cpp
+++ b/python/walk-with-traj/designer.cpp
@@ -8,9 +8,6 @@
 
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!
 // This line must be the first include
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
-#include <boost/python/return_internal_reference.hpp>
 #include <crocoddyl/core/activation-base.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/algorithm/model.hpp>

--- a/python/walk-with-traj/foot_trajectory.cpp
+++ b/python/walk-with-traj/foot_trajectory.cpp
@@ -2,10 +2,6 @@
 #include <sstream>
 
 // keep this line on top
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
-#include <boost/python/return_internal_reference.hpp>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <sobec/walk-with-traj/foot_trajectory.hpp>
 

--- a/python/walk-with-traj/horizon_manager.cpp
+++ b/python/walk-with-traj/horizon_manager.cpp
@@ -9,9 +9,6 @@
 
 #include "sobec/fwd.hpp"
 // keep this line on top
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
-#include <boost/python/return_internal_reference.hpp>
 #include <crocoddyl/core/activation-base.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <sobec/walk-with-traj/horizon_manager.hpp>

--- a/python/walk-with-traj/model_factory.cpp
+++ b/python/walk-with-traj/model_factory.cpp
@@ -1,8 +1,5 @@
 #include <pinocchio/fwd.hpp>  // Must be included first!
 // keep this line on top
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
-#include <boost/python/return_internal_reference.hpp>
 #include <crocoddyl/core/activation-base.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <sobec/walk-with-traj/model_factory.hpp>

--- a/python/walk-with-traj/ocp.cpp
+++ b/python/walk-with-traj/ocp.cpp
@@ -1,8 +1,5 @@
 #include "sobec/ocp.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
-#include <boost/python/return_internal_reference.hpp>
 #include <crocoddyl/core/activation-base.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!

--- a/python/walk-with-traj/ocp.cpp
+++ b/python/walk-with-traj/ocp.cpp
@@ -1,4 +1,4 @@
-#include "sobec/ocp.hpp"
+#include "sobec/walk-with-traj/ocp.hpp"
 
 #include <crocoddyl/core/activation-base.hpp>
 #include <eigenpy/eigenpy.hpp>

--- a/python/walk-with-traj/wbc.cpp
+++ b/python/walk-with-traj/wbc.cpp
@@ -64,16 +64,6 @@ void exposeWBC() {
   bp::enum_<LocomotionType>("LocomotionType")
       .value("WALKING", LocomotionType::WALKING)
       .value("STANDING", LocomotionType::STANDING);
-  bp::class_<std::vector<pinocchio::SE3>>("vector_pinocchio_se3_")
-      .def(bp::vector_indexing_suite<std::vector<pinocchio::SE3>>())
-      .def("__init__",
-           make_constructor(constructVectorFromList<pinocchio::SE3>))
-      .def("__repr__", &displayVector<pinocchio::SE3>);
-
-  bp::class_<std::vector<eVector3>>("vector_eigen_vector3_")
-      .def(bp::vector_indexing_suite<std::vector<eVector3>>())
-      .def("__init__", make_constructor(constructVectorFromList<eVector3>))
-      .def("__repr__", &displayVector<eVector3>);
 
   bp::class_<WBC>("WBC", bp::init<>())
       .def("initialize", &initialize,

--- a/python/walk-with-traj/wbc.cpp
+++ b/python/walk-with-traj/wbc.cpp
@@ -2,10 +2,6 @@
 #include <sstream>
 
 // keep this line on top
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
-#include <boost/python/return_internal_reference.hpp>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <crocoddyl/core/activation-base.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <sobec/walk-with-traj/wbc.hpp>

--- a/python/walk-with-traj/wbc_horizon.cpp
+++ b/python/walk-with-traj/wbc_horizon.cpp
@@ -2,9 +2,6 @@
 #include <sstream>
 
 // keep this line on top
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
-#include <boost/python/return_internal_reference.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <crocoddyl/core/activation-base.hpp>
 #include <eigenpy/eigenpy.hpp>
@@ -40,9 +37,9 @@ void initialize(WBCHorizon &self, const bp::dict &settings,
 template <typename T>
 boost::shared_ptr<std::vector<T>> constructVectorFromList(const bp::list &in) {
   boost::shared_ptr<std::vector<T>> ptr = boost::make_shared<std::vector<T>>();
-  ptr->resize(bp::len(in));
-  for (int i = 0; i < bp::len(in); ++i) {
-    (*ptr)[i] = boost::python::extract<T>(in[i]);
+  ptr->resize((std::size_t)bp::len(in));
+  for (long i = 0; i < bp::len(in); ++i) {
+    (*ptr)[(std::size_t)i] = boost::python::extract<T>(in[i]);
   }
   return ptr;
 }

--- a/python/walk-with-traj/wbc_horizon.cpp
+++ b/python/walk-with-traj/wbc_horizon.cpp
@@ -69,11 +69,6 @@ void exposeWBCHorizon() {
            make_constructor(constructVectorFromList<pinocchio::SE3>))
       .def("__repr__", &displayVector<pinocchio::SE3>);
 
-  bp::class_<std::vector<eVector3>>("vector_eigen_vector3_")
-      .def(bp::vector_indexing_suite<std::vector<eVector3>>())
-      .def("__init__", make_constructor(constructVectorFromList<eVector3>))
-      .def("__repr__", &displayVector<eVector3>);
-
   bp::class_<WBCHorizon>("WBCHorizon", bp::init<>())
       .def("initialize", &initialize,
            bp::args("self", "settings", "design", "horizon", "q0", "v0",

--- a/python/walk-with-traj/wbc_horizon.cpp
+++ b/python/walk-with-traj/wbc_horizon.cpp
@@ -1,10 +1,11 @@
-#include <pinocchio/multibody/fwd.hpp>  // Must be included first!
-#include <sstream>
+#include <pinocchio/multibody/fwd.hpp>
+// Must be included first!
 
-// keep this line on top
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <crocoddyl/core/activation-base.hpp>
 #include <eigenpy/eigenpy.hpp>
+#include <sstream>
+// keep this line on top
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <sobec/walk-with-traj/wbc_horizon.hpp>
 
 #include "sobec/fwd.hpp"

--- a/python/walk-without-think/mpc.cpp
+++ b/python/walk-without-think/mpc.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/walk-without-think/mpc.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <crocoddyl/core/solvers/fddp.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/multibody/fwd.hpp>  // Must be included first!

--- a/python/walk-without-think/ocp.cpp
+++ b/python/walk-without-think/ocp.cpp
@@ -8,8 +8,6 @@
 
 #include "sobec/walk-without-think/ocp.hpp"
 
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
 #include <crocoddyl/core/solvers/fddp.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <pinocchio/fwd.hpp>

--- a/src/py2cpp.cpp
+++ b/src/py2cpp.cpp
@@ -1,6 +1,5 @@
 #include "sobec/py2cpp.hpp"
 
-#include <boost/python.hpp>
 #include <crocoddyl/core/utils/exception.hpp>
 #include <sobec/walk-without-think/mpc.hpp>
 


### PR DESCRIPTION
In eigenpy 2.8.0 we merged a new feature from PR stack-of-tasks/eigenpy#325 porting the new version of `StdVectorPythonVisitor` from Pinocchio's upcoming version `3.x` to eigenpy itself. This PR updates the code in `std-containers.cpp` to use this code when this new eigenpy is available. Otherwise: it falls back to using the header from Pinocchio (version 3 or 2).

This PR also:
* updates the pre-commit config to *not* sort includes anymore
* uses `eigenpy::enableEigenPySpecific<Eigen::VectorXi>()` instead of the macro `ENABLE_SPECIFIC_MATRIX_TYPE` (which is not namespaced and doesn't say it comes from eigenpy)
* fixes some warning about structs being declared as `class`
* fixes a possible double-export issue coming from `walk-with-traj`
* add Python stubs using pybind11-stubgen (from recent cmake versions)
* removes includes of boost/python in favour of using eigenpy/eigenpy.hpp everywhere (this was discussed [in this PR on crocoddyl](https://github.com/loco-3d/crocoddyl/pull/1112))

The point about removing `#include <boost/python.hpp>` extends to including Boost.Python but not eigenpy.
Starting from [eigenpy 2.9.0](https://github.com/stack-of-tasks/eigenpy/commit/e9ba801d6563ce7a7aecaf9ca37eea54f5073714), a new header covering alignment issues to support full vectorization is included in `<eigenpy/eigenpy.hpp>` and *needs* to be included in order to get vectorization support everywhere.  
As a rule of thumb, Boost.Python should never be included directly.