### PR TITLE
Restored possibility to use default kinematic limits

### DIFF
--- a/src/walk-with-traj/model_factory.cpp
+++ b/src/walk-with-traj/model_factory.cpp
@@ -26,6 +26,17 @@ void ModelMaker::initialize(const ModelMakerSettings &settings,
 
   x0_.resize(designer_.get_rModel().nq + designer_.get_rModel().nv);
   x0_ << designer_.get_q0(), Eigen::VectorXd::Zero(designer_.get_rModel().nv);
+
+  if (settings_.lowKinematicLimits.size() == 0) {
+    // Using default values for kinematic bounds
+    settings_.lowKinematicLimits.resize(state_->get_nq() - 7);
+    settings_.highKinematicLimits.resize(state_->get_nq() - 7);
+    settings_.lowKinematicLimits =
+        designer_.get_rModel().lowerPositionLimit.tail(state_->get_nq() - 7);
+    settings_.highKinematicLimits =
+        designer_.get_rModel().upperPositionLimit.tail(state_->get_nq() - 7);
+  }
+
   initialized_ = true;
 }
 


### PR DESCRIPTION
This pull request restores the possibility to use default kinematics limits in the JointLimit cost.
This feature was removed by the last PR (https://github.com/MeMory-of-MOtion/sobec/pull/74).

In my opinion, we should only use the limits provided in the robot model to make sure we always have consistent values between different parts of the code. It is still possible to modify those limits with provided parameters when creating the robot model.
