### PR TITLE
Update gitignore: ignore all build*-prefixed dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 log/*
-build/*
+build*/
 install/*
 **/__pycache__/*
 .vscode/*
@@ -9,7 +9,6 @@ install/*
 dg*
 *anticipated-state*
 bak
-build
 .old
 mpc/nahuel
 python3


### PR DESCRIPTION
This change makes the .gitignore file ignore all directories prefixed by `build*/`

(Useful when there are multiple build dirs in the working tree)