### PR TITLE
CMake: fix Apple config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 log/*
-build/*
+build*/
 install/*
 **/__pycache__/*
 .vscode/*
@@ -9,7 +9,6 @@ install/*
 dg*
 *anticipated-state*
 bak
-build
 .old
 mpc/nahuel
 python3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,12 +38,15 @@ endif()
 include("${JRL_CMAKE_MODULES}/base.cmake")
 include("${JRL_CMAKE_MODULES}/boost.cmake")
 include("${JRL_CMAKE_MODULES}/stubs.cmake")
+include("${JRL_CMAKE_MODULES}/apple.cmake")
 
 # Project definition
 compute_project_args(PROJECT_ARGS LANGUAGES CXX)
 project(${PROJECT_NAME} ${PROJECT_ARGS})
 
 add_compile_options(-Wno-error)
+
+apply_default_apple_configuration()
 
 # Project dependencies
 if(BUILD_PYTHON_INTERFACE)


### PR DESCRIPTION
This PR adds the cmake submodule for Apple platforms and applies the default configuration.